### PR TITLE
Fix connected status on iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ build/
 .last_build_id
 Podfile.lock
 local.properties
+
+.idea

--- a/example/lib/controller.dart
+++ b/example/lib/controller.dart
@@ -99,6 +99,10 @@ class MidiControlsState extends State<MidiControls> {
     return Container(
       child: Column(
         children: <Widget>[
+          Text(
+            widget.device.name,
+            style: Theme.of(context).textTheme.headline5,
+          ),
           SteppedSelector('Channel', _channel + 1, 1, 16, _onChannelChanged),
           SteppedSelector(
               'Controller', _controller, 0, 127, _onControllerChanged),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,14 +27,14 @@ class _MyAppState extends State<MyApp> {
 
       switch (data) {
         case "deviceFound":
-          setState(() {});
           break;
-        // case "deviceOpened":
-        //   break;
+      // case "deviceOpened":
+      //   break;
         default:
-          // print("Unhandled setup change: $data");
+        // print("Unhandled setup change: $data");
           break;
       }
+      setState(() {});
     });
   }
 
@@ -80,18 +80,26 @@ class _MyAppState extends State<MyApp> {
                         return ListTile(
                           title: Text(
                             device.name,
-                            style: Theme.of(context).textTheme.headline,
+                            style: Theme.of(context).textTheme.headline5,
                           ),
                           subtitle: Text(
                               "ins:${device.inputPorts.length} outs:${device.outputPorts.length}"),
-                          trailing: device.type == "BLE"
-                              ? Icon(Icons.bluetooth)
-                              : null,
+                          trailing:
+                                device.type == "BLE"
+                                    ? Icon(Icons.bluetooth, color: device.connected ? Colors.green : Colors.black)
+                                    : device.connected ? Icon(Icons.check, color: Colors.green) : null,
                           onTap: () {
-                            _midiCommand.connectToDevice(device);
+                            if (!device.connected) {
+                              _midiCommand.connectToDevice(device);
+                            }
                             Navigator.of(context).push(MaterialPageRoute<Null>(
                               builder: (_) => ControllerPage(device),
                             ));
+                          },
+                          onLongPress: () {
+                            device.connected ? _midiCommand.disconnectDevice(device) : _midiCommand.connectToDevice(device);
+                            setState(() {
+                            });
                           },
                         );
                       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command
 description: A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices. Wraps CoreMIDI and android.media.midi in a thin dart/flutter layer.
-version: 0.3.7
+version: 0.3.8
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:


### PR DESCRIPTION
### Fixed bug iOS  

- Connected status was not always shown correctly. This was due to SwiftFlutterMidiCommandPlugin.getDevices() using the wrong id when looking at connectedDevices. 
- Reworked SwiftFlutterMidiCommandPlugin to use a new class Device to encapsulate attributes before return to dart (eventually to simply return theDevice object rather than a Map).
- Front end updated so that f you do a long press it connects to the device and shows a green connected check mark or Bluetooth green icon. 

For testing, I suggest you use the existing SwiftFlutterMidiCommandPlugin and do long press on device and see that device doe snot show connected. Then use new SwiftFlutterMidiCommandPlugin and see that connected status is updated.