### PR TITLE
Allow to create virtual MIDI devices on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.0-dev.6
+Added startBluetoothCentral() function
+
 ## 0.4.0-dev.5
 Fixed an issue with receiving consecutive SysEx messages on iOS
 Split packet into the (max) size reported by the connected device instead of fixed to 20 bytes, on iOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.4.0-dev.6
-Added startBluetoothCentral() function
+- Improved bluetooth state handling:
+  - Start bluetooth subsystem only when you want, not automatically
+  - Allow to retrieve bluetooth state before starting scanning
+  - Allow to observe bluetooth state (poweredOn, poweredOff, ...)
+  - Prepare user to grant bluetooth permissions
+  - Show feedback about the bluetooth state when scanning
 
 ## 0.4.0-dev.5
 Fixed an issue with receiving consecutive SysEx messages on iOS

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Import flutter_midi_command
 `import 'package:flutter_midi_command/flutter_midi_command.dart';`
 
 - Get a list of available MIDI devices by calling `MidiCommand().devices` which returns a list of `MidiDevice`
+- Start bluetooth subsystem by calling `MidiCommand().startBluetoothCentral()`
 - Start scanning for BLE MIDI devices by calling `MidiCommand().startScanningForBluetoothDevices()`
 - Connect to a specific `MidiDevice` by calling `MidiCommand.connectToDevice(selectedDevice)`
 - Stop scanning for BLE MIDI devices by calling `MidiCommand().stopScanningForBluetoothDevices()`
@@ -42,4 +43,5 @@ See example folder for how to use.
 For help getting started with Flutter, view our online
 [documentation](https://flutter.io/).
 
-For help on editing plugin code, view the [documentation](https://flutter.io/developing-packages/#edit-plugin-package).
+For help on editing plugin code, view the [documentation](https://flutter.io/pwd
+developing-packages/#edit-plugin-package).

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # flutter_midi_command
 
-A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices. 
+A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices.
 
 Wraps CoreMIDI/android.media.midi/ALSA in a thin dart/flutter layer.
 Supports
+
 - USB and BLE MIDI connections on Android
 - USB, network(session), virtual MIDI devices and BLE MIDI connections on iOS and macOS.
 - ALSA Midi on Linux
+- Create own virtual MIDI devices on iOS
 
 ## To install
 
@@ -15,7 +17,6 @@ Supports
 - In ios/Podfile uncomment and change the platform to 10.0 `platform :ios, '10.0'`
 - On iOS, After building, Add a NSBluetoothAlwaysUsageDescription and NSLocalNetworkUsageDescription to info.plist in the generated Xcode project.
 - On Linux, make sure ALSA is installed.
-
 
 ## Getting Started
 
@@ -34,6 +35,7 @@ Import flutter_midi_command
 - Listen for incoming MIDI messages on from the current device by subscribing to `MidiCommand().onMidiDataReceived`, after which the listener will recieve inbound MIDI messages as an UInt8List of variable length.
 - Send a MIDI message by calling `MidiCommand.sendData(data)`, where data is an UInt8List of bytes following the MIDI spec.
 - Or use the various `MidiCommand` subtypes to send PC, CC, NoteOn and NoteOff messages.
+- On iOS use `MidiCommand().addVirtualDevice(name: "Your Device Name")` to create a virtual MIDI destination and a virtual MIDI source. These virtual MIDI devices show up in other apps and can be used by other apps to send and receive MIDI to or from your app. To make this feature work, enable background audio for your app, i.e., add key `UIBackgroundModes` with value `audio` to your app's `info.plist` file.
 
 See example folder for how to use.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.invisiblewrench.flutter_midi_command"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -186,11 +186,11 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
       }
 
       "addVirtualDevice" -> {
-        result.success(null)
+        result.notImplemented()
       }
 
       "removeVirtualDevice" -> {
-        result.success(null)
+        result.notImplemented()
       }
 
       else -> {

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -184,6 +184,15 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
         teardown()
         result.success(null)
       }
+
+      "addVirtualDevice" -> {
+        result.success(null)
+      }
+
+      "removeVirtualDevice" -> {
+        result.success(null)
+      }
+
       else -> {
         result.notImplemented()
       }

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -153,6 +153,14 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
       "getDevices" -> {
         result.success(listOfDevices())
       }
+      "startBluetoothCentral" -> {
+        val errorMsg = tryToInitBT()
+        if (errorMsg != null) {
+          result.error("ERROR", errorMsg, null)
+        } else {
+          result.success(null)
+        }
+      }
       "scanForDevices" -> {
         val errorMsg = startScanningLeDevices()
         if (errorMsg != null) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.4.32'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 22 21:24:01 CET 2021
+#Thu Jan 06 14:26:46 CET 2022
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -25,7 +25,11 @@
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>Connect to Bluetooth MIDI Devices</string>
 	<key>NSLocalNetworkUsageDescription</key>
-    <string>Connect to Network MIDI Session</string>
+	<string>Connect to Network MIDI Session</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/example/lib/controller.dart
+++ b/example/lib/controller.dart
@@ -5,7 +5,7 @@ import 'package:flutter_midi_command/flutter_midi_command.dart';
 import 'package:flutter_midi_command/flutter_midi_command_messages.dart';
 
 class ControllerPage extends StatelessWidget {
-  MidiDevice device;
+  final MidiDevice device;
 
   ControllerPage(this.device);
 
@@ -21,7 +21,7 @@ class ControllerPage extends StatelessWidget {
 }
 
 class MidiControls extends StatefulWidget {
-  MidiDevice device;
+  final MidiDevice device;
 
   MidiControls(this.device);
 
@@ -48,7 +48,8 @@ class MidiControlsState extends State<MidiControls> {
       var data = packet.data;
       var timestamp = packet.timestamp;
       var device = packet.device;
-      print("data $data @ time $timestamp from device ${device.name}:${device.id}");
+      print(
+          "data $data @ time $timestamp from device ${device.name}:${device.id}");
 
       var status = data[0];
 
@@ -90,7 +91,8 @@ class MidiControlsState extends State<MidiControls> {
       child: Column(
         children: <Widget>[
           SteppedSelector('Channel', _channel + 1, 1, 16, _onChannelChanged),
-          SteppedSelector('Controller', _controller, 0, 127, _onControllerChanged),
+          SteppedSelector(
+              'Controller', _controller, 0, 127, _onControllerChanged),
           SlidingSelector('Value', _value, 0, 127, _onValueChanged),
         ],
       ),
@@ -112,7 +114,8 @@ class MidiControlsState extends State<MidiControls> {
   _onValueChanged(int newValue) {
     setState(() {
       _value = newValue;
-      CCMessage(channel: _channel, controller: _controller, value: _value).send();
+      CCMessage(channel: _channel, controller: _controller, value: _value)
+          .send();
     });
   }
 }
@@ -124,7 +127,8 @@ class SteppedSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  SteppedSelector(this.label, this.value, this.minValue, this.maxValue, this.callback);
+  SteppedSelector(
+      this.label, this.value, this.minValue, this.maxValue, this.callback);
 
   @override
   Widget build(BuildContext context) {
@@ -159,7 +163,8 @@ class SlidingSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  SlidingSelector(this.label, this.value, this.minValue, this.maxValue, this.callback);
+  SlidingSelector(
+      this.label, this.value, this.minValue, this.maxValue, this.callback);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   StreamSubscription<String>? _setupSubscription;
+  StreamSubscription<String>? _bluetoothStateSubscription;
   MidiCommand _midiCommand = MidiCommand();
 
   @override
@@ -21,11 +22,19 @@ class _MyAppState extends State<MyApp> {
     super.initState();
 
     _midiCommand.startBluetoothCentral();
+
     _midiCommand.startScanningForBluetoothDevices().catchError((err) {
       print("Error $err");
     });
     _setupSubscription = _midiCommand.onMidiSetupChanged?.listen((data) {
       print("setup changed $data");
+      setState(() {});
+    });
+
+    print(_midiCommand.bluetoothState);
+    _bluetoothStateSubscription =
+        _midiCommand.onBluetoothStateChanged?.listen((data) {
+      print("bluetooth state change $data");
       setState(() {});
     });
 
@@ -37,6 +46,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void dispose() {
     _setupSubscription?.cancel();
+    _bluetoothStateSubscription?.cancel();
     super.dispose();
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_midi_command/flutter_midi_command.dart';
 import 'controller.dart';
+import 'dart:io' show Platform;
 
 void main() => runApp(new MyApp());
 
@@ -26,6 +27,10 @@ class _MyAppState extends State<MyApp> {
       print("setup changed $data");
       setState(() {});
     });
+
+    if (Platform.isIOS) {
+      _midiCommand.addVirtualDevice(name: "Flutter MIDI Command");
+    }
   }
 
   @override

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,9 @@ class _MyAppState extends State<MyApp> {
           actions: <Widget>[
             IconButton(
                 onPressed: () {
-                  _midiCommand.startScanningForBluetoothDevices().catchError((err) {
+                  _midiCommand
+                      .startScanningForBluetoothDevices()
+                      .catchError((err) {
                     print("Error $err");
                   });
                   setState(() {});
@@ -92,8 +94,11 @@ class _MyAppState extends State<MyApp> {
                         device.name,
                         style: Theme.of(context).textTheme.headline5,
                       ),
-                      subtitle: Text("ins:${device.inputPorts.length} outs:${device.outputPorts.length}"),
-                      leading: Icon(device.connected ? Icons.radio_button_on : Icons.radio_button_off),
+                      subtitle: Text(
+                          "ins:${device.inputPorts.length} outs:${device.outputPorts.length}"),
+                      leading: Icon(device.connected
+                          ? Icons.radio_button_on
+                          : Icons.radio_button_off),
                       trailing: Icon(_deviceIconForType(device.type)),
                       onLongPress: () {
                         Navigator.of(context).push(MaterialPageRoute<Null>(
@@ -106,7 +111,9 @@ class _MyAppState extends State<MyApp> {
                           _midiCommand.disconnectDevice(device);
                         } else {
                           print("connect");
-                          _midiCommand.connectToDevice(device).then((_) => print("device connected async"));
+                          _midiCommand
+                              .connectToDevice(device)
+                              .then((_) => print("device connected async"));
                         }
                       },
                     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -20,6 +20,7 @@ class _MyAppState extends State<MyApp> {
   void initState() {
     super.initState();
 
+    _midiCommand.startBluetoothCentral();
     _midiCommand.startScanningForBluetoothDevices().catchError((err) {
       print("Error $err");
     });

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import flutter_midi_command
+import shared_preferences_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   SwiftFlutterMidiCommandPlugin.register(with: registry.registrar(forPlugin: "SwiftFlutterMidiCommandPlugin"))
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -165,6 +165,8 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
     public func startBluetoothCentralWhenNeeded(){
         if(manager == nil){
             manager = CBCentralManager.init(delegate: self, queue: DispatchQueue.global(qos: .userInteractive))
+
+          bluetoothStateHandler.send(data: getBluetooCentralStateAsString())
         }
     }
 
@@ -172,19 +174,19 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
         startBluetoothCentralWhenNeeded();
         switch(manager.state){
         case CBManagerState.poweredOn:
-            return "poweredOn";
+            return "poweredOn"
         case CBManagerState.poweredOff:
-            return "poweredOff";
+            return "poweredOff"
         case CBManagerState.resetting:
-            return "resetting";
+            return "resetting"
         case CBManagerState.unauthorized:
-            return "unauthorized";
+            return "unauthorized"
         case CBManagerState.unknown:
-            return "unknown";
+            return "unknown"
         case CBManagerState.unsupported:
-            return "unsupported";
+            return "unsupported"
         @unknown default:
-            return "other";
+            return "other"
         }
     }
 
@@ -195,6 +197,9 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             startBluetoothCentralWhenNeeded();
             result(nil);
             break;
+        case "bluetoothState":
+          result(getBluetooCentralStateAsString());
+          break;
         case "scanForDevices":
             startBluetoothCentralWhenNeeded();
             print("\(manager.state.rawValue)")
@@ -836,7 +841,7 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
 
     // Central
     public func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        print("central did update state \(central.state.rawValue)")
+        print("central did update state \(getBluetooCentralStateAsString())")
         bluetoothStateHandler.send(data: getBluetooCentralStateAsString());
     }
 

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -928,7 +928,7 @@ class ConnectedVirtualOrNativeDevice : ConnectedDevice {
     MIDIPortDispose(outputPort)
   }
 
-  var buffer = UnsafeMutablePointer<MIDIPacket>.allocate(capacity: 2) // Don't know why I need to setup two here. If I setup 1 I'm getting a crash.
+  var buffer = UnsafeMutablePointer<MIDIPacket>.allocate(capacity: 2) // Don't know why I need to a capacity of 2 here. If I setup 1 I'm getting a crash.
 
   func handlePacketList(_ packetList:UnsafePointer<MIDIPacketList>, srcConnRefCon:UnsafeMutableRawPointer?) {
     let packets = packetList.pointee

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -28,6 +28,11 @@ func displayName(endpoint: MIDIEndpointRef) -> String {
   return SwiftFlutterMidiCommandPlugin.getMIDIProperty(kMIDIPropertyDisplayName, fromObject: endpoint);
 }
 
+
+func stringToId(str: String) -> UInt32 {
+    return UInt32(str.hash & 0xFFFF)
+}
+
 public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, FlutterPlugin {
 
     // MIDI
@@ -70,10 +75,6 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
     deinit {
         NotificationCenter.default.removeObserver(self)
         MIDIClientDispose(midiClient)
-    }
-
-    func stringToId(str: String) -> UInt32 {
-      return UInt32(str.hash & 0xFFFF)
     }
 
     func setup(_ registrar: FlutterPluginRegistrar) {

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -1049,7 +1049,7 @@ class ConnectedNativeDevice : ConnectedVirtualOrNativeDevice {
     override func handlePacketList(_ packetList:UnsafePointer<MIDIPacketList>, srcConnRefCon:UnsafeMutableRawPointer?) {
         let packets = packetList.pointee
         let packet:MIDIPacket = packets.packet
-        var ap = UnsafeMutablePointer<MIDIPacket>.allocate(capacity: 1)
+        var ap = buffer
         ap.initialize(to:packet)
 
         let deviceInfo = ["name" : name,

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -28,6 +28,9 @@ func displayName(endpoint: MIDIEndpointRef) -> String {
   return SwiftFlutterMidiCommandPlugin.getMIDIProperty(kMIDIPropertyDisplayName, fromObject: endpoint);
 }
 
+func appName() -> String {
+    return Bundle.main.infoDictionary?[kCFBundleNameKey as String] as! String;
+}
 
 func stringToId(str: String) -> UInt32 {
     return UInt32(str.hash & 0xFFFF)

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -1215,7 +1215,7 @@ class ConnectedOwnVirtualDevice : ConnectedVirtualOrNativeDevice {
 
         if ( uniqueID != 0 )
         {
-            let s = MIDIObjectSetIntegerProperty(virtualDestinationEndpoint, kMIDIPropertyUniqueID, uniqueID);
+            let s = MIDIObjectSetIntegerProperty(virtualDestinationEndpoint, kMIDIPropertyUniqueID, uniqueID)
             if ( s == kMIDIIDNotUnique )
             {
                 uniqueID = 0;
@@ -1223,10 +1223,10 @@ class ConnectedOwnVirtualDevice : ConnectedVirtualOrNativeDevice {
         }
         // Save the ID
         if ( uniqueID == 0 ) {
-            let s = MIDIObjectGetIntegerProperty(virtualDestinationEndpoint, kMIDIPropertyUniqueID, &uniqueID);
+            let s = MIDIObjectGetIntegerProperty(virtualDestinationEndpoint, kMIDIPropertyUniqueID, &uniqueID)
 
             if ( s == noErr ) {
-                defaults.set(uniqueID, forKey: "FlutterMIDICommand Saved Virtual Destination ID \(deviceName)");
+                defaults.set(uniqueID, forKey: "FlutterMIDICommand Saved Virtual Destination ID \(deviceName)")
             }
             else {
                 print("Error: \(s) while setting unique ID for virtuel endpoint");

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -102,8 +102,6 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             self.handleMIDINotification(notification)
         }
 
-        manager = CBCentralManager.init(delegate: self, queue: DispatchQueue.global(qos: .userInteractive))
-
 #if os(iOS)
          session = MIDINetworkSession.default()
          session?.isEnabled = true
@@ -156,11 +154,20 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
         }
     }
 
+    public func startBluetoothCentralWhenNeeded(){
+        if(manager == nil){
+            manager = CBCentralManager.init(delegate: self, queue: DispatchQueue.global(qos: .userInteractive))
+        }
+    }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
 //        print("call method \(call.method)")
         switch call.method {
+        case "startBluetoothCentral":
+            startBluetoothCentralWhenNeeded();
+            result(nil);
         case "scanForDevices":
+            startBluetoothCentralWhenNeeded();
             print("\(manager.state.rawValue)")
             if manager.state == CBManagerState.poweredOn {
                 print("Start discovery")
@@ -173,6 +180,7 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             }
             break
         case "stopScanForDevices":
+            startBluetoothCentralWhenNeeded();
             manager.stopScan()
             break
         case "getDevices":
@@ -1316,7 +1324,7 @@ class ConnectedBLEDevice : ConnectedDevice, CBPeripheralDelegate {
 
             let writeType = CBCharacteristicWriteType.withoutResponse
             let packetSize = peripheral.maximumWriteValueLength(for:writeType)
-            print("packetSize = \(packetSize)")
+            // print("packetSize = \(packetSize)")
 
             var dataBytes = Data(bytes)
 

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -296,12 +296,18 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             }
             
             var entity : MIDIEntityRef = 0
-            var status = MIDIEndpointGetEntity(destination, &entity)                    
+            var status = MIDIEndpointGetEntity(destination, &entity)
+            if(status != noErr){
+                print("Error \(status) while calling MIDIEndpointGetEntity");
+            }
 
             let isNetwork = SwiftFlutterMidiCommandPlugin.isNetwork(device: entity)
             
             var device : MIDIDeviceRef = 0
             status = MIDIEntityGetDevice(entity, &device)
+            if(status != noErr){
+                print("Error \(status) while calling MIDIEntityGetDevice");
+            }
 
             let name = displayName(endpoint: destination);
 
@@ -343,11 +349,17 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             
             var entity : MIDIEntityRef = 0
             var status = MIDIEndpointGetEntity(source, &entity)
+            if(status != noErr){
+                print("Error \(status) while calling MIDIEndpointGetEntity");
+            }
             let isNetwork = SwiftFlutterMidiCommandPlugin.isNetwork(device: entity)
             let name = displayName(endpoint: source);
             
             var device : MIDIDeviceRef = 0
             status = MIDIEntityGetDevice(entity, &device)
+            if(status != noErr){
+                print("Error \(status) while calling MIDIEntityGetDevice");
+            }
 
             let entityCount = MIDIDeviceGetNumberOfEntities(device)
 //            print("entityCount \(entityCount)")
@@ -773,6 +785,10 @@ class ConnectedVirtualOrNativeDevice : ConnectedDevice {
       packet = MIDIPacketListAdd(packetList, 1024, packet, time, bytes.count, bytes)
 
       let status = MIDISend(outputPort, ep, packetList)
+      if(status != noErr){
+          print("Error \(status) while sending MIDI to virtual or physical destination")
+      }
+
       //print("send bytes \(bytes) on port \(outputPort) \(ep) status \(status)")
       packetList.deallocate()
     } else {
@@ -889,6 +905,9 @@ class ConnectedNativeDevice : ConnectedVirtualOrNativeDevice {
                 print("open default ports")
                 inSource = MIDIEntityGetSource(e, 0)
                 let status = MIDIPortConnectSource(inputPort, inSource!, &name)
+                if(status != noErr){
+                    print("Error \(status) while calling MIDIPortConnectSource");
+                }
                 outEndpoint = MIDIEntityGetDestination(e, 0)
             }
         }

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -148,6 +148,15 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             ownVirtualDevices.remove(existingDevice)
         }
     }
+
+    // Check if an endpoint is an own virtual destination or source
+    func isOwnVirtualEndpoint(endpoint: MIDIEndpointRef) -> Bool{
+        return ownVirtualDevices.contains { device in
+            device.virtualSourceEndpoint == endpoint || device.virtualDestinationEndpoint == endpoint
+        }
+    }
+
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
 //        print("call method \(call.method)")
         switch call.method {

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -121,6 +121,33 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
     }
 
 
+    // Create an own virtual device appearing in other apps.
+    // Other apps can use that device to send and receive MIDI to and from this app.
+    var ownVirtualDevices = Set<ConnectedOwnVirtualDevice>()
+
+    func findOrCreateOwnVirtualDevice(name: String) -> ConnectedOwnVirtualDevice{
+        let existingDevice = ownVirtualDevices.first(where: { device in
+            device.name == name
+        })
+
+        let result = existingDevice ?? ConnectedOwnVirtualDevice(name: name, streamHandler: rxStreamHandler, client: midiClient);
+        if(existingDevice == nil){
+            ownVirtualDevices.insert(result)
+        }
+
+        return result
+    }
+
+    func removeOwnVirtualDevice(name: String){
+        let existingDevice = ownVirtualDevices.first(where: { device in
+            device.name == name
+        })
+
+        if let existingDevice = existingDevice {
+            existingDevice.close()
+            ownVirtualDevices.remove(existingDevice)
+        }
+    }
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
 //        print("call method \(call.method)")
         switch call.method {

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -111,6 +111,16 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
          #endif
     }
 
+
+    func extractName(arguments: Any?) -> String?{
+        var name: String? = nil
+        if let packet = arguments as? Dictionary<String, Any> {
+            name = packet["name"] as? String
+        }
+        return name
+    }
+
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
 //        print("call method \(call.method)")
         switch call.method {

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -819,7 +819,8 @@ class ConnectedVirtualOrNativeDevice : ConnectedDevice {
 
     let deviceInfo = ["name" : name,
                       "id": String(id),
-                      "type":deviceType]
+                      "type":deviceType,
+                      "connected": String(true),]
 
     for _ in 0 ..< packets.numPackets {
       let p = ap.pointee

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -928,11 +928,13 @@ class ConnectedVirtualOrNativeDevice : ConnectedDevice {
     MIDIPortDispose(outputPort)
   }
 
+  var buffer = UnsafeMutablePointer<MIDIPacket>.allocate(capacity: 2) // Don't know why I need to setup two here. If I setup 1 I'm getting a crash.
+
   func handlePacketList(_ packetList:UnsafePointer<MIDIPacketList>, srcConnRefCon:UnsafeMutableRawPointer?) {
     let packets = packetList.pointee
     let packet:MIDIPacket = packets.packet
-    var ap = UnsafeMutablePointer<MIDIPacket>.allocate(capacity: 1)
-    ap.initialize(to:packet)
+    var ap = buffer;
+    buffer.initialize(to:packet)
 
     let deviceInfo = ["name" : name,
                       "id": String(id),
@@ -948,8 +950,6 @@ class ConnectedVirtualOrNativeDevice : ConnectedDevice {
       streamHandler.send(data: ["data": data, "timestamp":timestamp, "device":deviceInfo])
       ap = MIDIPacketNext(ap)
     }
-
-    //        ap.deallocate()
   }
 }
 

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -40,7 +40,9 @@ class MidiCommand {
 
   StreamController<Uint8List> _txStreamCtrl = StreamController.broadcast();
 
-  final _bluetoothStateStream = StreamController<BluetoothState>();
+  final _bluetoothStateStream = StreamController<BluetoothState>.broadcast();
+
+  var _bluetoothCentralIsStarted = false;
 
   BluetoothState _bluetoothState = BluetoothState.unknown;
   StreamSubscription? _onBluetoothStateChangedStreamSubscription;
@@ -84,8 +86,12 @@ class MidiCommand {
   /// Returns the state of the bluetooth central
   BluetoothState get bluetoothState => _bluetoothState;
 
-  /// Returns the bluetooth central state ()
+  /// Starts the bluetooth central
   Future<void> startBluetoothCentral() async {
+    if (_bluetoothCentralIsStarted) {
+      return;
+    }
+    _bluetoothCentralIsStarted = true;
     return _platform.startBluetoothCentral();
   }
 

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -94,4 +94,19 @@ class MidiCommand {
   Stream<Uint8List> get onMidiDataSent {
     return _txStreamCtrl.stream;
   }
+
+  /// Creates a virtual MIDI source
+  ///
+  /// The virtual MIDI source appears as a virtual port in other apps.
+  /// Other apps can receive MIDI from this source.
+  /// Currently only supported on iOS.
+  void addVirtualDevice({String? name}) {
+    _platform.addVirtualDevice(name: name);
+  }
+
+  /// Removes a previously created virtual MIDI source.
+  /// Currently only supported on iOS.
+  void removeVirtualDevice({String? name}) {
+    _platform.removeVirtualDevice(name: name);
+  }
 }

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -52,7 +52,7 @@ class MidiCommand {
   }
 
   /// Connects to the device
-  Future<void> connectToDevice(MidiDevice device) {
+  Future<void> connectToDevice(MidiDevice device) async {
     return _platform.connectToDevice(device);
   }
 

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -39,6 +39,13 @@ class MidiCommand {
     return _platform.devices;
   }
 
+  /// Starts bluetooth subsystem.
+  ///
+  /// Shows an alert requesting access rights for bluetooth.
+  Future<void> startBluetoothCentral() async {
+    return _platform.startBluetoothCentral();
+  }
+
   /// Starts scanning for BLE MIDI devices
   ///
   /// Found devices will be included in the list returned by [devices]

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -4,7 +4,8 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:flutter_midi_command_linux/flutter_midi_command_linux.dart';
 import 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart';
-export 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart' show MidiDevice, MidiPacket, MidiPort;
+export 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart'
+    show MidiDevice, MidiPacket, MidiPort;
 
 class MidiCommand {
   factory MidiCommand() {
@@ -14,13 +15,20 @@ class MidiCommand {
     return _instance!;
   }
 
-  MidiCommand._();
+  MidiCommand._() {
+    _listenToBluetoothState();
+  }
 
   static MidiCommand? _instance;
 
   static MidiCommandPlatform? __platform;
 
   StreamController<Uint8List> _txStreamCtrl = StreamController.broadcast();
+
+  String _bluetoothState = 'unknown';
+  _listenToBluetoothState() {
+    _platform.onBluetoothStateChanged?.listen((s) => _bluetoothState = s);
+  }
 
   /// Get the platform specific implementation
   static MidiCommandPlatform get _platform {
@@ -39,9 +47,15 @@ class MidiCommand {
     return _platform.devices;
   }
 
-  /// Starts bluetooth subsystem.
-  ///
-  /// Shows an alert requesting access rights for bluetooth.
+  /// Stream firing events whenever the bluetooth state changes
+  Stream<String>? get onBluetoothStateChanged {
+    return _platform.onBluetoothStateChanged;
+  }
+
+  /// Returns the state of the bluetooth central
+  String get bluetoothState => _bluetoothState;
+
+  /// Returns the bluetooth central state ()
   Future<void> startBluetoothCentral() async {
     return _platform.startBluetoothCentral();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,17 +15,17 @@ dependencies:
   flutter_midi_command_platform_interface:
     git: 
       url: git@github.com:gatzsche/flutter_midi_command_platform_interface.git
-      ref: 69c86c8
+      ref: af2f85b
   
   # TODO: Set back, once pull requests have been merged
   # flutter_midi_command_linux: ^0.2.0-dev.1
   flutter_midi_command_linux:
     git: 
       url: git@github.com:gatzsche/flutter_midi_command_linux.git
-      ref: master
+      ref: fd414bd
 
 dev_dependencies:
-  flutter_test:
+  flutter_test: 
     sdk: flutter
 
 # For information on the generic Dart part of this file, see the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command
 description: A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices. Wraps CoreMIDI and android.media.midi in a thin dart/flutter layer.
-version: 0.4.0-dev.5
+version: 0.4.0-dev.6
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:
@@ -15,14 +15,14 @@ dependencies:
   flutter_midi_command_platform_interface:
     git: 
       url: git@github.com:gatzsche/flutter_midi_command_platform_interface.git
-      ref: af2f85b
+      ref: master
   
   # TODO: Set back, once pull requests have been merged
   # flutter_midi_command_linux: ^0.2.0-dev.1
   flutter_midi_command_linux:
     git: 
       url: git@github.com:gatzsche/flutter_midi_command_linux.git
-      ref: fd414bd
+      ref: master
 
 dev_dependencies:
   flutter_test: 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,15 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^0.4.0-dev.1
-  flutter_midi_command_linux: ^0.2.0-dev.1
+  # TODO: Set back, once pull requests have been merged
+  # flutter_midi_command_platform_interface: ^0.4.0-dev.1
+  flutter_midi_command_platform_interface:
+    git: git@github.com:gatzsche/flutter_midi_command_platform_interface.git
+  
+  # TODO: Set back, once pull requests have been merged
+  # flutter_midi_command_linux: ^0.2.0-dev.1
+  flutter_midi_command_linux:
+    git: git@github.com:gatzsche/flutter_midi_command_linux.git
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,12 +13,16 @@ dependencies:
   # TODO: Set back, once pull requests have been merged
   # flutter_midi_command_platform_interface: ^0.4.0-dev.1
   flutter_midi_command_platform_interface:
-    git: git@github.com:gatzsche/flutter_midi_command_platform_interface.git
+    git: 
+      url: git@github.com:gatzsche/flutter_midi_command_platform_interface.git
+      ref: 69c86c8
   
   # TODO: Set back, once pull requests have been merged
   # flutter_midi_command_linux: ^0.2.0-dev.1
   flutter_midi_command_linux:
-    git: git@github.com:gatzsche/flutter_midi_command_linux.git
+    git: 
+      url: git@github.com:gatzsche/flutter_midi_command_linux.git
+      ref: master
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
With this pull request, it is possible to create virtual MIDI devices on iOS.
These virtual MIDI devices show up in other apps. Other apps can now send and receive MIDI to or from your own app using these virtual MIDI ports.

While merging this pull request, please do the following steps: 

1. Merge my previous pull request to flutter_midi_command_platform_interface.git
2. Edit pubspec.yaml and replace the references to 
- git@github.com:gatzsche/flutter_midi_command_platform_interface.git as well 
- git@github.com:gatzsche/flutter_midi_command_linux.git

Let me know if you have any questions. 

Gabriel