### PR TITLE
Fix: Network Session on iOS and macOS + Crash with timestamp on 32-bit devices because of not using an UInt64

### DIFF
--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -1112,7 +1112,7 @@ class ConnectedNativeDevice : ConnectedVirtualOrNativeDevice {
             let p = ap.pointee
             var tmp = p.data
             let data = Data(bytes: &tmp, count: Int(p.length))
-            let timestamp = Int(round(Double(p.timeStamp) * timestampFactor))
+            let timestamp = UInt64(round(Double(p.timeStamp) * timestampFactor))
 //            print("data \(data) timestamp \(timestamp)")
             streamHandler.send(data: ["data": data, "timestamp":timestamp, "device":deviceInfo])
             ap = MIDIPacketNext(ap)

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -327,7 +327,7 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, CBCentralManagerDelegate, 
             }
         } else // if type == "native" || if type == "virtual"
         {
-            let device = type == "native" ? ConnectedNativeDevice(id: deviceId, type: type, streamHandler: rxStreamHandler, client: midiClient, ports:ports)
+            let device = (type == "native" || type == "network") ? ConnectedNativeDevice(id: deviceId, type: type, streamHandler: rxStreamHandler, client: midiClient, ports:ports)
                 : ConnectedVirtualDevice(id: deviceId, type: type, streamHandler: rxStreamHandler, client: midiClient, ports:ports)
             print("connected to \(device) \(deviceId)")
             connectedDevices[deviceId] = device


### PR DESCRIPTION
Network Session on iOS and macOS broke while adding the Virtual Device feature. Also, this fix a crash on 32-bit devices since the timestamp was not converted to an UInt64.