### PR TITLE
added android:exported="true" to manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
     <application>
                 <service android:name=".VirtualDeviceService"
                     android:permission="android.permission.BIND_MIDI_DEVICE_SERVICE"
-                    android:enabled="false">
+                    android:enabled="false"
+                    android:exported="true">
                     <intent-filter>
                         <action android:name="android.media.midi.MidiDeviceService" />
                     </intent-filter>


### PR DESCRIPTION
Android 12 requires to explicitly declare the 'android:exported' attribute for app components.

[see android docs](https://developer.android.com/about/versions/12/behavior-changes-12)

this change allowed me to compile my app for android with sdk 31. i hope its helpful!! 

Thanks :)