### PR TITLE
iOS: Prevent showing bluetooth permission alert right at application start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.6
+Fixed an issue showing the OS bluetooth permission alerat before
+refresh button was pressed.
+
 ## 0.4.5
 Added Pitch bend message type
 More controls in example app

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,6 +34,8 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
+  bool _didAskForBluetoothPermissions = false;
+
   @override
   void dispose() {
     _setupSubscription?.cancel();
@@ -55,6 +57,10 @@ class _MyAppState extends State<MyApp> {
   }
 
   Future<void> _informUserAboutBluetoothPermissions(BuildContext context) async {
+    if (_didAskForBluetoothPermissions) {
+      return;
+    }
+
     await showDialog<void>(
       context: context,
       barrierDismissible: false,
@@ -74,6 +80,8 @@ class _MyAppState extends State<MyApp> {
         );
       },
     );
+
+    _didAskForBluetoothPermissions = true;
 
     return;
   }

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -1427,11 +1427,28 @@ class ConnectedBLEDevice : ConnectedDevice, CBPeripheralDelegate {
                 return
             }
 
-            // Insert header(and empty timstamp high) and timestamp low in front of BLE Midi message
-            dataBytes.insert(0x80, at: 0)
-            dataBytes.insert(0x80, at: 0)
-            
-            enqueueMidiData(bytes: dataBytes)
+            // In bluetooth MIDI we need to send each midi command separately
+            var currentBuffer = Data();
+            for i in 0..<dataBytes.count {
+                let byte = dataBytes[i]
+                
+                // Insert header(and empty timstamp high) and timestamp
+                // low in front of BLE Midi message
+                if((byte & 0x80) != 0){
+                    currentBuffer.insert(0x80, at: 0)
+                    currentBuffer.insert(0x80, at: 0)
+                }
+                currentBuffer.append(byte);
+                
+                // Send each MIDI command separately
+                let endReached = i == (dataBytes.count - 1);
+                let isCompleteCommand = endReached || (dataBytes[i+1] & 0x80) != 0;
+                
+                if(isCompleteCommand){
+                    enqueueMidiData(bytes: currentBuffer)
+                    currentBuffer = Data()
+                }
+            }
         } else {
             print("No peripheral/characteristic in device")
         }

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -24,9 +24,7 @@ class MidiCommand {
     return _instance!;
   }
 
-  MidiCommand._() {
-    _listenToBluetoothState();
-  }
+  MidiCommand._();
 
   dispose() {
     _bluetoothStateStream.close();
@@ -88,7 +86,8 @@ class MidiCommand {
       return;
     }
     _bluetoothCentralIsStarted = true;
-    return _platform.startBluetoothCentral();
+    await _platform.startBluetoothCentral();
+    await _listenToBluetoothState();
   }
 
   /// Wait for the blueetooth state to be initialized

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command
 description: A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices. Wraps CoreMIDI and android.media.midi in a thin dart/flutter layer.
-version: 0.4.5
+version: 0.4.6
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:


### PR DESCRIPTION
I want to show the bluetooth permission alert only when I'm actually using bluetooth MIDI, not before. This is fixed now.