### PR TITLE
altered null_checks for latest flutter sdk in kotlin file

### DIFF
--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -164,8 +164,8 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
 
     when (call.method) {
       "sendData" -> {
-        var args = call.arguments<Map<String, Any>>()
-        sendData(args["data"] as ByteArray, args["timestamp"] as? Long, args["deviceId"]?.toString())
+        var args : Map<String,Any>? = call.arguments()
+        sendData(args?.get("data") as ByteArray, args["timestamp"] as? Long, args["deviceId"]?.toString())
         result.success(null)
       }
       "getDevices" -> {
@@ -198,7 +198,7 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
       }
       "connectToDevice" -> {
         var args = call.arguments<Map<String, Any>>()
-        var device = (args["device"] as Map<String, Any>)
+        var device = (args?.get("device") as Map<String, Any>)
 //        var portList = (args["ports"] as List<Map<String, Any>>).map{
 //          Port(if (it["id"].toString() is String) it["id"].toString().toInt() else 0 , it["type"].toString())
 //        }
@@ -208,7 +208,7 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
       }
       "disconnectDevice" -> {
         var args = call.arguments<Map<String, Any>>()
-        disconnectDevice(args["id"].toString())
+        args?.get("id")?.let { disconnectDevice(it.toString()) }
         result.success(null)
       }
       "teardown" -> {
@@ -346,11 +346,11 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
     discoveredDevices.clear()
   }
 
-
+//fun onRequestPermissionsResult(p0: Int, p1: Array<(out) String!>, p2: IntArray): Boolean
   override fun onRequestPermissionsResult(
           requestCode: Int,
-          permissions: Array<out String>?,
-          grantResults: IntArray?): Boolean {
+          permissions: Array<out String>,
+          grantResults: IntArray): Boolean {
     Log.d("FlutterMIDICommand", "Permissions code: $requestCode grantResults: $grantResults")
 
 


### PR DESCRIPTION
Hi!

In found that the library does not compile anymore on the flutter beta channel. I think there was a change in null-check requirements in the native code communication between kotlin and flutter code. Ive made some null checking changes and it works again.

Those were the errors I beforehand:

```
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (36, 1): Class 'FlutterMidiCommandPlugin' is not abstract and does not implement abstract member public abstract fun onRequestPermissionsResult(p0: Int, p1: Array<(out) String!>, p2: IntArray): Boolean defined in io.flutter.plugin.common.PluginRegistry.RequestPermissionsResultListener
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (168, 18): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Map<String, Any>?
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (168, 45): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Map<String, Any>?
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (168, 73): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Map<String, Any>?
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (201, 23): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Map<String, Any>?
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (211, 26): Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type Map<String, Any>?
e: /Users/anz/.pub-cache/hosted/pub.dartlang.org/flutter_midi_command-0.4.5/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt: (350, 3): 'onRequestPermissionsResult' overrides nothing
```

After correcting the kotlin file, everything is dandy again :)
