### PR TITLE
Replace deprecated styles and use official lints in example app

### DIFF
--- a/example/lib/controller.dart
+++ b/example/lib/controller.dart
@@ -53,7 +53,8 @@ class MidiControlsState extends State<MidiControls> {
       var data = packet.data;
       var timestamp = packet.timestamp;
       var device = packet.device;
-      print("data $data @ time $timestamp from device ${device.name}:${device.id}");
+      print(
+          "data $data @ time $timestamp from device ${device.name}:${device.id}");
 
       var status = data[0];
 
@@ -112,22 +113,23 @@ class MidiControlsState extends State<MidiControls> {
     return ListView(
       padding: EdgeInsets.all(12),
       children: <Widget>[
-        Text("Channel", style: Theme.of(context).textTheme.headline6),
+        Text("Channel", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector('Channel', _channel + 1, 1, 16, _onChannelChanged),
         Divider(),
-        Text("CC", style: Theme.of(context).textTheme.headline6),
-        SteppedSelector('Controller', _controller, 0, 127, _onControllerChanged),
+        Text("CC", style: Theme.of(context).textTheme.titleLarge),
+        SteppedSelector(
+            'Controller', _controller, 0, 127, _onControllerChanged),
         SlidingSelector('Value', _ccValue, 0, 127, _onValueChanged),
         Divider(),
-        Text("NRPN", style: Theme.of(context).textTheme.headline6),
+        Text("NRPN", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector('Parameter', _nrpnCtrl, 0, 16383, _onNRPNCtrlChanged),
         SlidingSelector('Parameter', _nrpnCtrl, 0, 16383, _onNRPNCtrlChanged),
         SlidingSelector('Value', _nrpnValue, 0, 16383, _onNRPNValueChanged),
         Divider(),
-        Text("PC", style: Theme.of(context).textTheme.headline6),
+        Text("PC", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector('Program', _pcValue, 0, 127, _onProgramChanged),
         Divider(),
-        Text("Pitch Bend", style: Theme.of(context).textTheme.headline6),
+        Text("Pitch Bend", style: Theme.of(context).textTheme.titleLarge),
         Slider(
             value: _pitchValue,
             max: 1,
@@ -176,14 +178,16 @@ class MidiControlsState extends State<MidiControls> {
     setState(() {
       _ccValue = newValue;
     });
-    CCMessage(channel: _channel, controller: _controller, value: _ccValue).send();
+    CCMessage(channel: _channel, controller: _controller, value: _ccValue)
+        .send();
   }
 
   _onNRPNValueChanged(int newValue) {
     setState(() {
       _nrpnValue = newValue;
     });
-    NRPN4Message(channel: _channel, parameter: _nrpnCtrl, value: _nrpnValue).send();
+    NRPN4Message(channel: _channel, parameter: _nrpnCtrl, value: _nrpnValue)
+        .send();
   }
 
   _onNRPNCtrlChanged(int newValue) {
@@ -207,7 +211,8 @@ class SteppedSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  SteppedSelector(this.label, this.value, this.minValue, this.maxValue, this.callback);
+  SteppedSelector(
+      this.label, this.value, this.minValue, this.maxValue, this.callback);
 
   @override
   Widget build(BuildContext context) {
@@ -242,7 +247,8 @@ class SlidingSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  SlidingSelector(this.label, this.value, this.minValue, this.maxValue, this.callback);
+  SlidingSelector(
+      this.label, this.value, this.minValue, this.maxValue, this.callback);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/controller.dart
+++ b/example/lib/controller.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_midi_command/flutter_midi_command.dart';
 import 'package:flutter_midi_command/flutter_midi_command_messages.dart';
@@ -8,13 +9,13 @@ import 'package:flutter_virtual_piano/flutter_virtual_piano.dart';
 class ControllerPage extends StatelessWidget {
   final MidiDevice device;
 
-  ControllerPage(this.device);
+  const ControllerPage(this.device, {Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('Controls'),
+        title: const Text('Controls'),
       ),
       body: MidiControls(device),
     );
@@ -24,11 +25,11 @@ class ControllerPage extends StatelessWidget {
 class MidiControls extends StatefulWidget {
   final MidiDevice device;
 
-  MidiControls(this.device);
+  const MidiControls(this.device, {Key? key}) : super(key: key);
 
   @override
   MidiControlsState createState() {
-    return new MidiControlsState();
+    return MidiControlsState();
   }
 }
 
@@ -43,18 +44,24 @@ class MidiControlsState extends State<MidiControls> {
 
   // StreamSubscription<String> _setupSubscription;
   StreamSubscription<MidiPacket>? _rxSubscription;
-  MidiCommand _midiCommand = MidiCommand();
+  final MidiCommand _midiCommand = MidiCommand();
 
   @override
   void initState() {
-    print('init controller');
+    if (kDebugMode) {
+      print('init controller');
+    }
     _rxSubscription = _midiCommand.onMidiDataReceived?.listen((packet) {
-      print('received packet $packet');
+      if (kDebugMode) {
+        print('received packet $packet');
+      }
       var data = packet.data;
       var timestamp = packet.timestamp;
       var device = packet.device;
-      print(
-          "data $data @ time $timestamp from device ${device.name}:${device.id}");
+      if (kDebugMode) {
+        print(
+            "data $data @ time $timestamp from device ${device.name}:${device.id}");
+      }
 
       var status = data[0];
 
@@ -102,6 +109,7 @@ class MidiControlsState extends State<MidiControls> {
     super.initState();
   }
 
+  @override
   void dispose() {
     // _setupSubscription?.cancel();
     _rxSubscription?.cancel();
@@ -111,24 +119,24 @@ class MidiControlsState extends State<MidiControls> {
   @override
   Widget build(BuildContext context) {
     return ListView(
-      padding: EdgeInsets.all(12),
+      padding: const EdgeInsets.all(12),
       children: <Widget>[
         Text("Channel", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector('Channel', _channel + 1, 1, 16, _onChannelChanged),
-        Divider(),
+        const Divider(),
         Text("CC", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector(
             'Controller', _controller, 0, 127, _onControllerChanged),
         SlidingSelector('Value', _ccValue, 0, 127, _onValueChanged),
-        Divider(),
+        const Divider(),
         Text("NRPN", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector('Parameter', _nrpnCtrl, 0, 16383, _onNRPNCtrlChanged),
         SlidingSelector('Parameter', _nrpnCtrl, 0, 16383, _onNRPNCtrlChanged),
         SlidingSelector('Value', _nrpnValue, 0, 16383, _onNRPNValueChanged),
-        Divider(),
+        const Divider(),
         Text("PC", style: Theme.of(context).textTheme.titleLarge),
         SteppedSelector('Program', _pcValue, 0, 127, _onProgramChanged),
-        Divider(),
+        const Divider(),
         Text("Pitch Bend", style: Theme.of(context).textTheme.titleLarge),
         Slider(
             value: _pitchValue,
@@ -138,11 +146,11 @@ class MidiControlsState extends State<MidiControls> {
             onChangeEnd: (_) {
               _onPitchChanged(0);
             }),
-        Divider(),
+        const Divider(),
         SizedBox(
           height: 80,
           child: VirtualPiano(
-            noteRange: RangeValues(48, 76),
+            noteRange: const RangeValues(48, 76),
             onNotePressed: (note, vel) {
               NoteOnMessage(note: note, velocity: 100).send();
             },
@@ -211,8 +219,10 @@ class SteppedSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  SteppedSelector(
-      this.label, this.value, this.minValue, this.maxValue, this.callback);
+  const SteppedSelector(
+      this.label, this.value, this.minValue, this.maxValue, this.callback,
+      {Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -221,7 +231,7 @@ class SteppedSelector extends StatelessWidget {
       children: <Widget>[
         Text(label),
         IconButton(
-            icon: Icon(Icons.remove_circle),
+            icon: const Icon(Icons.remove_circle),
             onPressed: (value > minValue)
                 ? () {
                     callback(value - 1);
@@ -229,7 +239,7 @@ class SteppedSelector extends StatelessWidget {
                 : null),
         Text(value.toString()),
         IconButton(
-            icon: Icon(Icons.add_circle),
+            icon: const Icon(Icons.add_circle),
             onPressed: (value < maxValue)
                 ? () {
                     callback(value + 1);
@@ -247,8 +257,10 @@ class SlidingSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  SlidingSelector(
-      this.label, this.value, this.minValue, this.maxValue, this.callback);
+  const SlidingSelector(
+      this.label, this.value, this.minValue, this.maxValue, this.callback,
+      {Key? key})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,7 +29,8 @@ class _MyAppState extends State<MyApp> {
       setState(() {});
     });
 
-    _bluetoothStateSubscription = _midiCommand.onBluetoothStateChanged.listen((data) {
+    _bluetoothStateSubscription =
+        _midiCommand.onBluetoothStateChanged.listen((data) {
       print("bluetooth state change $data");
       setState(() {});
     });
@@ -57,7 +58,8 @@ class _MyAppState extends State<MyApp> {
     }
   }
 
-  Future<void> _informUserAboutBluetoothPermissions(BuildContext context) async {
+  Future<void> _informUserAboutBluetoothPermissions(
+      BuildContext context) async {
     if (_didAskForBluetoothPermissions) {
       return;
     }
@@ -67,8 +69,10 @@ class _MyAppState extends State<MyApp> {
       barrierDismissible: false,
       builder: (BuildContext context) {
         return AlertDialog(
-          title: const Text('Please Grant Bluetooth Permissions to discover BLE MIDI Devices.'),
-          content: const Text('In the next dialog we might ask you for bluetooth permissions.\n'
+          title: const Text(
+              'Please Grant Bluetooth Permissions to discover BLE MIDI Devices.'),
+          content: const Text(
+              'In the next dialog we might ask you for bluetooth permissions.\n'
               'Please grant permissions to make bluetooth MIDI possible.'),
           actions: <Widget>[
             TextButton(
@@ -103,7 +107,8 @@ class _MyAppState extends State<MyApp> {
                   if (newValue) {
                     _midiCommand.addVirtualDevice(name: "Flutter MIDI Command");
                   } else {
-                    _midiCommand.removeVirtualDevice(name: "Flutter MIDI Command");
+                    _midiCommand.removeVirtualDevice(
+                        name: "Flutter MIDI Command");
                   }
                 }),
             Builder(builder: (context) {
@@ -114,20 +119,27 @@ class _MyAppState extends State<MyApp> {
 
                     // Start bluetooth
                     print("start ble central");
-                    await _midiCommand.startBluetoothCentral().catchError((err) {
+                    await _midiCommand
+                        .startBluetoothCentral()
+                        .catchError((err) {
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content: Text(err),
                       ));
                     });
 
                     print("wait for init");
-                    await _midiCommand.waitUntilBluetoothIsInitialized().timeout(Duration(seconds: 5), onTimeout: () {
+                    await _midiCommand
+                        .waitUntilBluetoothIsInitialized()
+                        .timeout(Duration(seconds: 5), onTimeout: () {
                       print("Failed to initialize Bluetooth");
                     });
 
                     // If bluetooth is powered on, start scanning
-                    if (_midiCommand.bluetoothState == BluetoothState.poweredOn) {
-                      _midiCommand.startScanningForBluetoothDevices().catchError((err) {
+                    if (_midiCommand.bluetoothState ==
+                        BluetoothState.poweredOn) {
+                      _midiCommand
+                          .startScanningForBluetoothDevices()
+                          .catchError((err) {
                         print("Error $err");
                       });
 
@@ -136,19 +148,25 @@ class _MyAppState extends State<MyApp> {
                       ));
                     } else {
                       final messages = {
-                        BluetoothState.unsupported: 'Bluetooth is not supported on this device.',
-                        BluetoothState.poweredOff: 'Please switch on bluetooth and try again.',
+                        BluetoothState.unsupported:
+                            'Bluetooth is not supported on this device.',
+                        BluetoothState.poweredOff:
+                            'Please switch on bluetooth and try again.',
                         BluetoothState.poweredOn: 'Everything is fine.',
-                        BluetoothState.resetting: 'Currently resetting. Try again later.',
+                        BluetoothState.resetting:
+                            'Currently resetting. Try again later.',
                         BluetoothState.unauthorized:
                             'This app needs bluetooth permissions. Please open settings, find your app and assign bluetooth access rights and start your app again.',
-                        BluetoothState.unknown: 'Bluetooth is not ready yet. Try again later.',
-                        BluetoothState.other: 'This should never happen. Please inform the developer of your app.',
+                        BluetoothState.unknown:
+                            'Bluetooth is not ready yet. Try again later.',
+                        BluetoothState.other:
+                            'This should never happen. Please inform the developer of your app.',
                       };
 
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         backgroundColor: Colors.red,
-                        content: Text(messages[_midiCommand.bluetoothState] ?? 'Unknown bluetooth state: ${_midiCommand.bluetoothState}'),
+                        content: Text(messages[_midiCommand.bluetoothState] ??
+                            'Unknown bluetooth state: ${_midiCommand.bluetoothState}'),
                       ));
                     }
 
@@ -181,10 +199,13 @@ class _MyAppState extends State<MyApp> {
                     return ListTile(
                       title: Text(
                         device.name,
-                        style: Theme.of(context).textTheme.headline5,
+                        style: Theme.of(context).textTheme.headlineSmall,
                       ),
-                      subtitle: Text("ins:${device.inputPorts.length} outs:${device.outputPorts.length}, ${device.id}, ${device.type}"),
-                      leading: Icon(device.connected ? Icons.radio_button_on : Icons.radio_button_off),
+                      subtitle: Text(
+                          "ins:${device.inputPorts.length} outs:${device.outputPorts.length}, ${device.id}, ${device.type}"),
+                      leading: Icon(device.connected
+                          ? Icons.radio_button_on
+                          : Icons.radio_button_off),
                       trailing: Icon(_deviceIconForType(device.type)),
                       onLongPress: () {
                         _midiCommand.stopScanningForBluetoothDevices();
@@ -202,8 +223,13 @@ class _MyAppState extends State<MyApp> {
                           _midiCommand.disconnectDevice(device);
                         } else {
                           print("connect");
-                          _midiCommand.connectToDevice(device).then((_) => print("device connected async")).catchError((err) {
-                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text("Error: ${(err as PlatformException?)?.message}")));
+                          _midiCommand
+                              .connectToDevice(device)
+                              .then((_) => print("device connected async"))
+                              .catchError((err) {
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                                content: Text(
+                                    "Error: ${(err as PlatformException?)?.message}")));
                           });
                         }
                       },

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the flutter_midi_command plugin.
 
 # The following line prevents the package from being accidentally published to
 # pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -17,24 +17,24 @@ dependencies:
     #   fluttermidicommand: ^x.y.z
     # See https://dart.dev/tools/pub/dependencies#version-constraints
     # The example app is bundled with the plugin so we use a path dependency on
-    # the parent directory to use the current plugin's version. 
+    # the parent directory to use the current plugin's version.
     path: ../
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.5
   flutter_virtual_piano: ^0.0.8
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  flutter_lints: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 
 # The following section is specific to Flutter.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -13,12 +13,13 @@ import 'package:flutter_midi_command_example/main.dart';
 void main() {
   testWidgets('Verify Platform version', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(const MyApp());
 
     // Verify that platform version is retrieved.
     expect(
       find.byWidgetPredicate(
-        (Widget widget) => widget is Text && widget.data!.startsWith('Running on:'),
+        (Widget widget) =>
+            widget is Text && widget.data!.startsWith('Running on:'),
       ),
       findsOneWidget,
     );


### PR DESCRIPTION
Replaced deprecated header styles with ones used in the current flutter version in the example app.

Added the current official flutter_lint back to the example app and applied all linter suggestions, bringing the style back to the current flutter standard and improved async safety by adding ```mounted``` checks to the scaffold messenger (as suggested by the linter).

this also got rid of all the warnings, that were shown by default in the example app.