### PR TITLE
Fixed parsing of SysEx message when using Bluetooth MIDI

### DIFF
--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -1683,7 +1683,7 @@ class ConnectedBLEDevice : ConnectedDevice, CBPeripheralDelegate {
                 
                 if ((((midiByte & 0x80) == 0x80) && (bleHandlerState != BLE_HANDLER_STATE.TIMESTAMP)) && (bleHandlerState != BLE_HANDLER_STATE.SYSEX_INT)) {
                     if (!bleSysExHasFinished) {
-                        if ((midiByte & 0xF7) == 0xF7)
+                        if ((midiByte & 0xFF) == 0xF7)
                         { // Sysex end
 //                            print("sysex end on byte \(midiByte)")
                           bleSysExHasFinished = true
@@ -1748,7 +1748,7 @@ class ConnectedBLEDevice : ConnectedDevice, CBPeripheralDelegate {
                     break
 
                   case BLE_HANDLER_STATE.SYSEX_INT:
-                    if ((midiByte & 0xF7) == 0xF7)
+                    if ((midiByte & 0xFF) == 0xF7)
                     { // Sysex end
 //                        print("sysex end")
                       bleSysExHasFinished = true

--- a/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
+++ b/ios/Classes/SwiftFlutterMidiCommandPlugin.swift
@@ -1683,15 +1683,8 @@ class ConnectedBLEDevice : ConnectedDevice, CBPeripheralDelegate {
                 
                 if ((((midiByte & 0x80) == 0x80) && (bleHandlerState != BLE_HANDLER_STATE.TIMESTAMP)) && (bleHandlerState != BLE_HANDLER_STATE.SYSEX_INT)) {
                     if (!bleSysExHasFinished) {
-                        if ((midiByte & 0xFF) == 0xF7)
-                        { // Sysex end
-//                            print("sysex end on byte \(midiByte)")
-                          bleSysExHasFinished = true
-                          bleHandlerState = BLE_HANDLER_STATE.SYSEX_END
-                        } else {
-//                            print("Set to SYSEX_INT")
-                            bleHandlerState = BLE_HANDLER_STATE.SYSEX_INT
-                        }
+//                      print("Set to SYSEX_INT")
+                        bleHandlerState = BLE_HANDLER_STATE.SYSEX_INT
                     } else {
                         bleHandlerState = BLE_HANDLER_STATE.TIMESTAMP
                     }


### PR DESCRIPTION
I found a bug around Bluetooth Midi timestamp.
In the current parsing algorithm like `if ((midiByte & 0xF7) == 0xF7)` ,
when a timestampLow that is over `F7` comes in, the parser misunderstands it as an End of Sys.Ex. message. 
Therefore, it appends the wrong data into sysExBuffer [here](https://github.com/InvisibleWrench/FlutterMidiCommand/blob/aaca327a433157c808bd4d1aca62408f44d72db4/ios/Classes/SwiftFlutterMidiCommandPlugin.swift#L1842).

![SysEx Packet](https://user-images.githubusercontent.com/38450059/233045992-99e7d882-2f98-42d5-9e88-04894a97f423.png)

I fixed and tested it, it seemed to work correctly.
I might have missed some cases, so please review my modifications.

c.f.) [This commit](https://github.com/InvisibleWrench/FlutterMidiCommand/commit/4a4fedcec7e0718475372a88204de303447fb3fe) added this conditionals.