### PR TITLE
depend on latest flutter_midi_command_linux

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,10 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_midi_command_platform_interface: ^0.4.0
-  flutter_midi_command_linux: ^0.1.5
+  flutter_midi_command_linux: ^0.3.0
 
 dev_dependencies:
-  flutter_test: 
+  flutter_test:
     sdk: flutter
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
Hi!

Ive been unable to update to the latest FMC 0.4.13 because of a dependency conflict with another package I am using (Rive).

The problem is a dependency conflict, since FMC was still depending on flutter_midi_command_linux 0.1.5, which depends on ffi 1.0.0 instead of the latest ffi 2.0.0.

Long story short,
would it be okay to update the dependency on flutter_midi_command_linux to the latest release 0.3.0 ?

This should not affect anyone, except increase compatibility.

Thx a lot!!!
