### PR TITLE
Fix reconnect issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,7 +43,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 21
+        minSdk = 24
     }
 
     dependencies {

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/BondedDevice.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/BondedDevice.kt
@@ -11,22 +11,17 @@ class BondedDevice  : Device {
     lateinit var device: BluetoothDevice
     lateinit var context: Context
 
-    var result:Result? = null
-
     var socket: BluetoothSocket? = null
-
     constructor(device: BluetoothDevice, context: Context) : super(device.address, "Bonded") {
         this.device = device
         this.context = context
 
         device.fetchUuidsWithSdp()
     }
-
-    override fun connectWithStreamHandler(streamHandler: FMCStreamHandler, connectResult:Result?) {
+    override fun connectWithStreamHandler(streamHandler: FMCStreamHandler) {
         Log.d("FlutterMIDICommand","connect bonded")
 
         this.setupStreamHandler = streamHandler
-        this.result = connectResult
 
 //      device.connectGatt(context, false, gattCallback, BluetoothDevice.TRANSPORT_LE )
 

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/ConnectedDevice.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/ConnectedDevice.kt
@@ -17,7 +17,7 @@ class ConnectedDevice : Device {
         this.setupStreamHandler = setupStreamHandler
     }
 
-    override fun connectWithStreamHandler(streamHandler: FMCStreamHandler, connectResult:Result?) {
+    override fun connectWithStreamHandler(streamHandler: FMCStreamHandler) {
         Log.d("FlutterMIDICommand","connectWithHandler")
 
         this.midiDevice.info?.let {
@@ -48,7 +48,6 @@ class ConnectedDevice : Device {
         }
 
         Handler().postDelayed({
-            connectResult?.success(null)
             setupStreamHandler?.send("deviceConnected")
         }, 2500)
     }
@@ -115,7 +114,11 @@ class ConnectedDevice : Device {
     class RXReceiver(stream: FMCStreamHandler, device: MidiDevice) : MidiReceiver() {
         val stream = stream
         var isBluetoothDevice = device.info.type == MidiDeviceInfo.TYPE_BLUETOOTH
-        val deviceInfo = mapOf("id" to if(isBluetoothDevice) device.info.properties.get(MidiDeviceInfo.PROPERTY_BLUETOOTH_DEVICE).toString() else device.info.id.toString(), "name" to device.info.properties.getString(MidiDeviceInfo.PROPERTY_NAME), "type" to if(isBluetoothDevice) "BLE" else "native")
+        val deviceInfo = mapOf(
+            "id" to if (isBluetoothDevice) (device.info.properties.get(MidiDeviceInfo.PROPERTY_BLUETOOTH_DEVICE) as BluetoothDevice).address else device.info.id.toString(),
+            "name" to device.info.properties.getString(MidiDeviceInfo.PROPERTY_NAME),
+            "type" to if (isBluetoothDevice) "BLE" else "native"
+        )
 
         // MIDI parsing
         enum class PARSER_STATE

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/Device.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/Device.kt
@@ -1,5 +1,6 @@
 package com.invisiblewrench.fluttermidicommand
 
+import android.bluetooth.BluetoothDevice
 import android.media.midi.MidiDevice
 import android.media.midi.MidiDeviceInfo
 import android.media.midi.MidiReceiver
@@ -26,7 +27,7 @@ abstract class Device {
     companion object {
         fun deviceIdForInfo(info: MidiDeviceInfo): String {
             var isBluetoothDevice = info.type == MidiDeviceInfo.TYPE_BLUETOOTH
-            var deviceId: String = if (isBluetoothDevice) info.properties.get(MidiDeviceInfo.PROPERTY_BLUETOOTH_DEVICE).toString() else info.id.toString()
+            var deviceId: String = if (isBluetoothDevice) (info.properties.get(MidiDeviceInfo.PROPERTY_BLUETOOTH_DEVICE) as BluetoothDevice).address else info.id.toString()
             return deviceId
         }
     }

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/Device.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/Device.kt
@@ -18,7 +18,7 @@ abstract class Device {
         this.type = type
     }
 
-    abstract fun connectWithStreamHandler(streamHandler: FMCStreamHandler, connectResult:Result?)
+    abstract fun connectWithStreamHandler(streamHandler: FMCStreamHandler)
 
     abstract fun send(data: ByteArray, timestamp: Long?)
 

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -195,6 +195,8 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
         val errorMsg =  connectToDevice(deviceId, device["type"].toString())
         if (errorMsg != null) {
           result.error("ERROR", errorMsg, null)
+        } else {
+          result.success(null)
         }
       }
       "disconnectDevice" -> {
@@ -602,8 +604,7 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
       Log.d("FlutterMIDICommand", "onDeviceOpened")
       it?.also {
         val device = ConnectedDevice(it, this@FlutterMidiCommandPlugin.setupStreamHandler)
-        var result = this@FlutterMidiCommandPlugin.ongoingConnections[device.id]
-        device.connectWithStreamHandler(rxStreamHandler, result)
+        device.connectWithStreamHandler(rxStreamHandler)
         Log.d("FlutterMIDICommand", "Opened device id ${device.id}")
         connectedDevices[device.id] = device
       }
@@ -628,6 +629,8 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
         connectedDevices[id]?.also {
           Log.d("FlutterMIDICommand","remove removed device $it")
           connectedDevices.remove(id)
+          discoveredDevices.removeIf { discoveredDevice -> discoveredDevice.address == id }
+          ongoingConnections.remove(id)
         }
         this@FlutterMidiCommandPlugin.setupStreamHandler.send("deviceLost")
       }


### PR DESCRIPTION
* Enable use of await when calling "connectToDevice" by adding result.success (and deleted redundant Result parameter in connectWithStreamHandler)
* Use Bluetooth address instead of toString(), because toString() replaces the hexadecimal digits of leftmost 4 bytes (in big endian order) with "XX", e.g., "XX:XX:XX:XX:12:34" from API level 34.
* Upgrade minSdk to 24

How to test: 
Connect and disconnect. The device is now able to connect after disconnect. 