### PR TITLE
Fix Gradle v8 compilation bug

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: "kotlin-android"
 
 android {
     if (project.android.hasProperty("namespace")) {
-        namespace = "com.invisiblewrench.flutter_midi_command"
+        namespace = "com.invisiblewrench.fluttermidicommand"
     }
 
     compileSdk = 34


### PR DESCRIPTION
When using this library with the newer Gradle 8 toolchain, it failed since the spelling of the namespace differed between the androidmanifest.xml and the build.gradle file.

i changed it to 'fluttermidicommand' since the project refers to that spelling everywhere else in the codebase.

everything works perfectly now with this change for me :)