### PR TITLE
Enable running on devices without midi support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next
+Adds a runtime check to ensure MIDI is available on the android device before starting. See #125 for further details.
+
 ## 0.5.2
 Added Recorder to Example App
 Merge PR #118, Thanks to Donkermand


### PR DESCRIPTION
Adding this plugin to an app will currently block it's install on any android device that doesn't declare support for "android.software.midi" (quite a few even quite new devices don't support MIDI it turns out). This is blocked becuaes of the feature declerations in `AndroidManifest.xml`.

This pull request doesn't change this behaviour, but adds a runtime check which means that if a developer overrides the feature decleration in their own app (with something like `<uses-feature android:name="android.software.midi" android:required="false" tools:node="replace" />`) their app will function fine (as long as they don't call any MIDI methods) on devices that don't support MIDI.

Currently, including this plugin in an app and disabling the feature requirement will crash the app on first launch on android.