### PR TITLE
Removed package name from AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.invisiblewrench.fluttermidicommand">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:name="android.software.midi" android:required="true"/>
     <uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>


### PR DESCRIPTION
Fixes an issue where building for Android was failing due to the following error:

```
Incorrect package="com.invisiblewrench.fluttermidicommand" found in source AndroidManifest.xml: /Users/rumori/.pub-cache/hosted/pub.dev/flutter_midi_command-0.5.2/android/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
Recommendation: remove package="com.invisiblewrench.fluttermidicommand" from the source AndroidManifest.xml: /Users/rumori/.pub-cache/hosted/pub.dev/flutter_midi_command-0.5.2/android/src/main/AndroidManifest.xml.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':flutter_midi_command:processDebugManifest'.
> A failure occurred while executing com.android.build.gradle.tasks.ProcessLibraryManifest$ProcessLibWorkAction
   > Incorrect package="com.invisiblewrench.fluttermidicommand" found in source AndroidManifest.xml: /Users/rumori/.pub-cache/hosted/pub.dev/flutter_midi_command-0.5.2/android/src/main/AndroidManifest.xml.
     Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
     Recommendation: remove package="com.invisiblewrench.fluttermidicommand" from the source AndroidManifest.xml: /Users/rumori/.pub-cache/hosted/pub.dev/flutter_midi_command-0.5.2/android/src/main/AndroidManifest.xml.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 842ms
Error: Gradle task assembleDebug failed with exit code 1
```