### PR TITLE
MidiDevice Added serviceUUIDs attribute in broadcast. 

### DIFF
--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/BluetoothDeviceExtension.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/BluetoothDeviceExtension.kt
@@ -1,0 +1,11 @@
+package com.invisiblewrench.fluttermidicommand
+
+import android.bluetooth.BluetoothDevice
+
+private val deviceServiceUUIDs = mutableMapOf<String, List<String>>()
+
+var BluetoothDevice.serviceUUIDs: List<String>
+    get() = deviceServiceUUIDs[address] ?: listOf()
+    set(value) {
+        deviceServiceUUIDs[address] = value
+    }

--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/Device.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/Device.kt
@@ -12,6 +12,7 @@ abstract class Device {
     lateinit var midiDevice: MidiDevice
     protected var receiver:MidiReceiver? = null
     protected var setupStreamHandler: FMCStreamHandler? = null
+    var serviceUUIDs: List<String> = listOf()
 
     constructor(id: String, type: String) {
         this.id = id

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -242,7 +242,7 @@ class MyAppState extends State<MyApp> {
                         style: Theme.of(context).textTheme.headlineSmall,
                       ),
                       subtitle: Text(
-                          "ins:${device.inputPorts.length} outs:${device.outputPorts.length}, ${device.id}, ${device.type}"),
+                          "ins:${device.inputPorts.length} outs:${device.outputPorts.length}, ${device.id}, ${device.type}, serviceUUID:${device.serviceUUIDs.first.str}"),
                       leading: Icon(device.connected
                           ? Icons.radio_button_on
                           : Icons.radio_button_off),


### PR DESCRIPTION
MidiDevice Added serviceUUIDs attribute in broadcast. 
Can filter Bluetooth devices during search phase.
In some scenarios, only a specific type of Bluetooth hardware devices needs to be displayed.