### PR TITLE
fix: resolve too many MIDI listeners for UID = xxxx

### DIFF
--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -109,9 +109,13 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
       return
     }
 
-    handler = Handler(context.mainLooper)
-    midiManager = context.getSystemService(Context.MIDI_SERVICE) as MidiManager
-    midiManager.registerDeviceCallback(deviceConnectionCallback, handler)
+    if (!::handler.isInitialized) {
+      handler = Handler(context.mainLooper)
+    }
+    if (!::midiManager.isInitialized) {
+      midiManager = context.getSystemService(Context.MIDI_SERVICE) as MidiManager
+      midiManager.registerDeviceCallback(deviceConnectionCallback, handler)
+    }
 
     rxStreamHandler = FMCStreamHandler(handler)
     rxChannel = EventChannel(messenger, "plugins.invisiblewrench.com/flutter_midi_command/rx_channel")


### PR DESCRIPTION
I have observed a number of crashes in the wild (although I've not been able to reproduce myself) due to repeated registration of the device callback against the MidiManager class.

On closer inspection, It does appear that it is possible when re-creating activities for this plugin to re-run this code multiple times without cleanly tearing it down.

Not sure if this is the best solution to the problem.