### PR TITLE
Android: Fix native device connection by matching `Device.deviceIdForInfo`

### DIFF
--- a/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
+++ b/android/src/main/kotlin/com/invisiblewrench/fluttermidicommand/FlutterMidiCommandPlugin.kt
@@ -419,7 +419,7 @@ class FlutterMidiCommandPlugin : FlutterPlugin, ActivityAware, MethodCallHandler
         midiManager.openBluetoothDevice(bleDevices.first(), deviceOpenedListener, handler)
       }
     } else if (type == "native") {
-      val devices =  midiManager.devices.filter { d -> d.id.toString() == deviceId }
+      val devices =  midiManager.devices.filter { d -> Device.deviceIdForInfo(d) == deviceId }
       if (devices.isEmpty()) {
         Log.d("FlutterMIDICommand", "not found device $devices")
         return "Device not found"


### PR DESCRIPTION
## Summary

- Problem: Connecting to a `type == "native"` device fails with "Device not found".
- Root cause: IDs were compared inconsistently — `connectToDevice()` used `d.id.toString()`, while device discovery and removal used `Device.deviceIdForInfo(...)`.
- Fix: In `connectToDevice(native)`, match devices using `Device.deviceIdForInfo(d)` for consistency with discovery.
- Scope: Android native MIDI devices only. No changes to BLE or virtual devices.

## Technical Details

- Change: Replace `midiManager.devices.filter { d.id.toString() == deviceId }` with `midiManager.devices.filter { Device.deviceIdForInfo(d) == deviceId }`.
- Rationale: `listOfDevices()` and device callbacks already generate IDs via `Device.deviceIdForInfo(...)`. Aligning `connectToDevice()` prevents mismatches.

## Testing

- Repro (before): Select a native device from the discovered list, attempt connection → "Device not found".
- Validation (after): Same device connects successfully; device is opened via `midiManager.openDevice(...)` without errors.

## Risk & Compatibility

- Backward compatibility: Improves ID consistency with existing code; no breaking API changes.
- Risk level: Low. The lookup method is now uniform across discovery, removal, and connection.