### PR TITLE
Upgrade file picker and csv packages in order to be compatible with win32 >= 6.2.0

### DIFF
--- a/example/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
+++ b/example/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+//
+// Generated file. Do not edit.
+//
+
+import PackageDescription
+
+let package = Package(
+    name: "FlutterGeneratedPluginSwiftPackage",
+    platforms: [
+        .iOS("13.0")
+    ],
+    products: [
+        .library(name: "FlutterGeneratedPluginSwiftPackage", type: .static, targets: ["FlutterGeneratedPluginSwiftPackage"])
+    ],
+    dependencies: [
+        .package(name: "file_picker", path: "../.packages/file_picker-12.0.0-beta.7"),
+        .package(name: "FlutterFramework", path: "../.packages/FlutterFramework")
+    ],
+    targets: [
+        .target(
+            name: "FlutterGeneratedPluginSwiftPackage",
+            dependencies: [
+                .product(name: "file-picker", package: "file_picker"),
+                .product(name: "FlutterFramework", package: "FlutterFramework")
+            ]
+        )
+    ]
+)

--- a/example/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Sources/FlutterGeneratedPluginSwiftPackage/FlutterGeneratedPluginSwiftPackage.swift
+++ b/example/ios/Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage/Sources/FlutterGeneratedPluginSwiftPackage/FlutterGeneratedPluginSwiftPackage.swift
@@ -1,0 +1,3 @@
+//
+// Generated file. Do not edit.
+//

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '12.0'
+platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,21 +2,28 @@ PODS:
   - Flutter (1.0.0)
   - flutter_midi_command (0.4.2):
     - Flutter
+  - universal_ble (0.0.1):
+    - Flutter
+    - FlutterMacOS
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_midi_command (from `.symlinks/plugins/flutter_midi_command/ios`)
+  - universal_ble (from `.symlinks/plugins/universal_ble/darwin`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   flutter_midi_command:
     :path: ".symlinks/plugins/flutter_midi_command/ios"
+  universal_ble:
+    :path: ".symlinks/plugins/universal_ble/darwin"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_midi_command: 760f0ec4b7c6d3034982f6045e878d9b7d01674e
+  universal_ble: cf52a7b3fd2e7c14d6d7262e9fdadb72ab6b88a6
 
-PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
+PODFILE CHECKSUM: cc1f88378b4bfcf93a6ce00d2c587857c6008d3b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/example/lib/controller.dart
+++ b/example/lib/controller.dart
@@ -10,7 +10,7 @@ import 'package:flutter_virtual_piano/flutter_virtual_piano.dart';
 class ControllerPage extends StatelessWidget {
   final MidiDevice device;
 
-  const ControllerPage(this.device, {Key? key}) : super(key: key);
+  const ControllerPage(this.device, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -26,7 +26,7 @@ class ControllerPage extends StatelessWidget {
 class MidiControls extends StatefulWidget {
   final MidiDevice device;
 
-  const MidiControls(this.device, {Key? key}) : super(key: key);
+  const MidiControls(this.device, {super.key});
 
   @override
   MidiControlsState createState() {
@@ -200,46 +200,46 @@ class MidiControlsState extends State<MidiControls> {
     );
   }
 
-  _onChannelChanged(int newValue) {
+  void _onChannelChanged(int newValue) {
     setState(() {
       _channel = newValue - 1;
     });
   }
 
-  _onControllerChanged(int newValue) {
+  void _onControllerChanged(int newValue) {
     setState(() {
       _controller = newValue;
     });
   }
 
-  _onProgramChanged(int newValue) {
+  void _onProgramChanged(int newValue) {
     setState(() {
       _pcValue = newValue;
     });
     PCMessage(channel: _channel, program: _pcValue).send();
   }
 
-  _onValueChanged(int newValue) {
+  void _onValueChanged(int newValue) {
     setState(() {
       _ccValue = newValue;
     });
     CCMessage(channel: _channel, controller: _controller, value: _ccValue).send();
   }
 
-  _onNRPNValueChanged(int newValue) {
+  void _onNRPNValueChanged(int newValue) {
     setState(() {
       _nrpnValue = newValue;
     });
     NRPN4Message(channel: _channel, parameter: _nrpnCtrl, value: _nrpnValue).send();
   }
 
-  _onNRPNCtrlChanged(int newValue) {
+  void _onNRPNCtrlChanged(int newValue) {
     setState(() {
       _nrpnCtrl = newValue;
     });
   }
 
-  _onPitchChanged(double newValue) {
+  void _onPitchChanged(double newValue) {
     setState(() {
       _pitchValue = newValue;
     });
@@ -265,7 +265,7 @@ class SteppedSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  const SteppedSelector(this.label, this.value, this.minValue, this.maxValue, this.callback, {Key? key}) : super(key: key);
+  const SteppedSelector(this.label, this.value, this.minValue, this.maxValue, this.callback, {super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -300,7 +300,7 @@ class SlidingSelector extends StatelessWidget {
   final int value;
   final Function(int) callback;
 
-  const SlidingSelector(this.label, this.value, this.minValue, this.maxValue, this.callback, {Key? key}) : super(key: key);
+  const SlidingSelector(this.label, this.value, this.minValue, this.maxValue, this.callback, {super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -10,7 +10,7 @@ import 'controller.dart';
 void main() => runApp(const MyApp());
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   MyAppState createState() => MyAppState();
@@ -55,7 +55,7 @@ class MyAppState extends State<MyApp> {
     super.dispose();
   }
 
-  _updateNetworkSessionState() async {
+  void _updateNetworkSessionState() async {
     var nse = await _midiCommand.isNetworkSessionEnabled;
     if (nse != null) {
       setState(() {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -151,6 +151,9 @@ class MyAppState extends State<MyApp> {
                     await _midiCommand
                         .startBluetoothCentral()
                         .catchError((err) {
+                          if (kDebugMode) {
+                            print("BLE Central Error $err");
+                          }
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                         content: Text(err),
                       ));

--- a/example/lib/recorder.dart
+++ b/example/lib/recorder.dart
@@ -1,6 +1,6 @@
 
 import 'dart:async';
-import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter_midi_command/flutter_midi_command.dart';
 import 'package:csv/csv.dart';
@@ -26,37 +26,41 @@ class MidiRecorder {
   StreamSubscription<MidiPacket>? _midiSub;
 
   void startRecording() {
+    print("Starting recording");
     _recording = true;
     _midiSub = MidiCommand().onMidiDataReceived?.listen((packet) {
+      print("Recording packet: ${packet.data.length} bytes");
       _messages.add(packet);
     });
   }
 
   void stopRecording() {
+    print("Stopping recording");
     _recording = false;
     _midiSub?.cancel();
   }
 
 
   void exportRecording() async {
-    var rows = _messages.map((e) => [e.timestamp, ...e.data.map((e) => e.toString())]).toList();
+    print("Writing ${_messages.length} messages to CSV file");
+    List<List<String>> rows = _messages.map<List<String>>((e) => [e.timestamp.toString(), ...e.data.map<String>((e) => e.toString())]).toList();
 
-    var csv = const ListToCsvConverter().convert(rows);
+    var data = csv.encode(rows);
+    Uint8List bytes = Uint8List.fromList(data.codeUnits);
 
-    String? outputFile = await FilePicker.platform.saveFile(
+    String? outputFile = await FilePicker.saveFile(
       dialogTitle: 'Please select an output file:',
       fileName: 'midi_recording.csv',
       type: FileType.custom,
       allowedExtensions: ['csv'],
+      bytes: bytes,
     );
 
     if (outputFile == null) {
-      // User canceled the picker
+      print("The user canceled the picker");
     } else {
-      await File(outputFile).writeAsString(csv);
+      print("Recorded ${bytes.length} bytes exported to $outputFile");
     }
-
-    print("recording exported");
   }
 
   void clearRecording() {

--- a/example/lib/recorder.dart
+++ b/example/lib/recorder.dart
@@ -25,20 +25,20 @@ class MidiRecorder {
 
   StreamSubscription<MidiPacket>? _midiSub;
 
-  startRecording() {
+  void startRecording() {
     _recording = true;
     _midiSub = MidiCommand().onMidiDataReceived?.listen((packet) {
       _messages.add(packet);
     });
   }
 
-  stopRecording() {
+  void stopRecording() {
     _recording = false;
     _midiSub?.cancel();
   }
 
 
-  exportRecording() async {
+  void exportRecording() async {
     var rows = _messages.map((e) => [e.timestamp, ...e.data.map((e) => e.toString())]).toList();
 
     var csv = const ListToCsvConverter().convert(rows);
@@ -59,7 +59,7 @@ class MidiRecorder {
     print("recording exported");
   }
 
-  clearRecording() {
+  void clearRecording() {
     _messages.clear();
   }
 }

--- a/example/lib/test.dart
+++ b/example/lib/test.dart
@@ -7,7 +7,7 @@ void main() {
 }
 
 class MainApp extends StatelessWidget {
-  const MainApp({Key? key}) : super(key: key);
+  const MainApp({super.key});
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +18,7 @@ class MainApp extends StatelessWidget {
 }
 
 class HomeView extends StatefulWidget {
-  const HomeView({Key? key}) : super(key: key);
+  const HomeView({super.key});
 
   @override
   State<HomeView> createState() => _HomeViewState();

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -1,6 +1,4 @@
 PODS:
-  - file_picker (0.0.1):
-    - FlutterMacOS
   - flutter_midi_command (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
@@ -9,14 +7,11 @@ PODS:
     - FlutterMacOS
 
 DEPENDENCIES:
-  - file_picker (from `Flutter/ephemeral/.symlinks/plugins/file_picker/macos`)
   - flutter_midi_command (from `Flutter/ephemeral/.symlinks/plugins/flutter_midi_command/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - universal_ble (from `Flutter/ephemeral/.symlinks/plugins/universal_ble/darwin`)
 
 EXTERNAL SOURCES:
-  file_picker:
-    :path: Flutter/ephemeral/.symlinks/plugins/file_picker/macos
   flutter_midi_command:
     :path: Flutter/ephemeral/.symlinks/plugins/flutter_midi_command/macos
   FlutterMacOS:
@@ -25,7 +20,6 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/universal_ble/darwin
 
 SPEC CHECKSUMS:
-  file_picker: e716a70a9fe5fd9e09ebc922d7541464289443af
   flutter_midi_command: c1a74de594e48e8fffd195a2ed5746161d507a48
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   universal_ble: cf52a7b3fd2e7c14d6d7262e9fdadb72ab6b88a6

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		F6088CB5AD8C4CAEF0253909 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 303361F6BA59A431BF1858B8 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
@@ -71,6 +72,9 @@
 		3A3AF070747DDC637905AF95 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		5AF7B4DC2518D333002A84B8 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		68D531B7B01B16EBD789AF1A /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		784666492D4C4C64000A1A5F /* FlutterFramework */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterFramework; path = ephemeral/Packages/.packages/FlutterFramework; sourceTree = "<group>"; };
+		78DABEA22ED26510000E7860 /* flutter_midi_command */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = flutter_midi_command; path = ../../../macos/flutter_midi_command; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		E65AFE4C7315E93A33532327 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
@@ -81,6 +85,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */,
 				F6088CB5AD8C4CAEF0253909 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -132,6 +137,9 @@
 		33CEB47122A05771004F2AC0 /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78DABEA22ED26510000E7860 /* flutter_midi_command */,
+				784666492D4C4C64000A1A5F /* FlutterFramework */,
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				335BBD1A22A9A15E00E9071D /* GeneratedPluginRegistrant.swift */,
 				33CEB47222A05771004F2AC0 /* Flutter-Debug.xcconfig */,
 				33CEB47422A05771004F2AC0 /* Flutter-Release.xcconfig */,
@@ -193,6 +201,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* example.app */;
 			productType = "com.apple.product-type.application";
@@ -232,6 +243,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -322,13 +336,11 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/file_picker/file_picker.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_midi_command/flutter_midi_command.framework",
 				"${BUILT_PRODUCTS_DIR}/universal_ble/universal_ble.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/file_picker.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_midi_command.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/universal_ble.framework",
 			);
@@ -649,6 +661,20 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = FlutterGeneratedPluginSwiftPackage;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 33CC10E52044A3C60003C045 /* Project object */;
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -22,15 +22,15 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.5
-  flutter_virtual_piano: ^0.0.8
-  csv: ^6.0.0
-  file_picker: ^8.0.6
+  cupertino_icons: ^1.0.9
+  flutter_virtual_piano: ^0.0.10
+  csv: ^8.0.0
+  file_picker: ^12.0.0-beta.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -6,7 +6,7 @@ description: Demonstrates how to use the flutter_midi_command plugin.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ publish_to: none
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:
-  sdk: ">=3.1.0 <4.0.0"
+  sdk: ">=3.10.0 <4.0.0"
   flutter: ">=3.11.0"
 
 dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,19 +2,24 @@ name: flutter_midi_command
 description: A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices. Wraps CoreMIDI and android.media.midi in a thin dart/flutter layer.
 
 version: 0.5.4
+publish_to: none
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 
 environment:
   sdk: ">=3.1.0 <4.0.0"
-  flutter: ">=2.11.0"
+  flutter: ">=3.11.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^0.4.1
+  flutter_midi_command_platform_interface: ^0.4.3
   flutter_midi_command_linux: ^0.3.0
   flutter_midi_command_windows: ^0.3.0
     
+  #  git:
+  #    url: https://github.com/kristofb/flutter_midi_command_windows.git
+  #    ref: 0b326c93e06eada007f43ab96942987bf10d7a57
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
In order to be able to upgrade important packages from applications, such as device_info_plus, package_info_plus, wakelock_plus, share_plus, we need to be able to use package win32 >= 6.2.0

This PR mainly changes win32 from v5 to v6.

I tested MIDI input and output with virtual devices, and with a keyboard connected through universal_ble with the given example.

Another PR concerns flutter_midi_command_windows.