### PR TITLE
fix: BLE MIDI peripherals connect but deliver no data on iOS

### DIFF
--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -73,7 +73,8 @@ class MidiCommand {
   /// `MidiCommand().logHandler = (m) => talker.debug(m);`
   void Function(String message)? logHandler;
 
-  void _log(String message) => logHandler?.call('[flutter_midi_command] $message');
+  void _log(String message) =>
+      logHandler?.call('[flutter_midi_command] $message');
   final Expando<_MidiDeviceRoute> _deviceRouteByInstance =
       Expando<_MidiDeviceRoute>('midi_device_route');
   final Map<String, _MidiDeviceRoute> _deviceRouteById =
@@ -208,7 +209,8 @@ class MidiCommand {
 
     final bleActive =
         _bleTransport != null && isTransportEnabled(MidiTransport.ble);
-    final bleDevices = bleActive ? await _bleTransport!.devices : <MidiDevice>[];
+    final bleDevices =
+        bleActive ? await _bleTransport!.devices : <MidiDevice>[];
     // BLE-transport devices (advertised name) indexed by id.
     final bleById = <String, MidiDevice>{
       for (final device in bleDevices) device.id: device,
@@ -383,7 +385,8 @@ class MidiCommand {
       device.setConnectionState(MidiConnectionState.disconnecting);
     }
     final route = _resolveDeviceRoute(device);
-    final isBleWithTransport = device.type == MidiDeviceType.ble &&
+    final isBleWithTransport =
+        device.type == MidiDeviceType.ble &&
         _bleTransport != null &&
         isTransportEnabled(MidiTransport.ble);
     _log(
@@ -461,7 +464,7 @@ class MidiCommand {
     if (_bleTransport != null && isTransportEnabled(MidiTransport.ble)) {
       streams.add(
         _mapPacketsToTypedEvents(
-          _bleTransport!.onMidiDataReceived,
+          _bleTransportPackets(),
           fallbackTransport: MidiTransport.ble,
         ),
       );
@@ -484,7 +487,7 @@ class MidiCommand {
       streams.add(_platform.onMidiDataReceived!);
     }
     if (_bleTransport != null && isTransportEnabled(MidiTransport.ble)) {
-      streams.add(_bleTransport!.onMidiDataReceived);
+      streams.add(_bleTransportPackets());
     }
     if (streams.isEmpty) {
       return null;
@@ -630,15 +633,10 @@ class MidiCommand {
 
     _log('Handoff: waiting for CoreMIDI counterpart of ${device.id}');
     while (DateTime.now().isBefore(deadline)) {
-      if (_deviceRouteById[device.id] == _MidiDeviceRoute.platform) {
-        // Already handed off (e.g. by a concurrent devices() refresh).
-        return;
-      }
       final platformDevices = await _platform.devices ?? <MidiDevice>[];
       MidiDevice? match;
       for (final candidate in platformDevices) {
-        if (candidate.id == device.id &&
-            candidate.type == MidiDeviceType.ble) {
+        if (candidate.id == device.id && candidate.type == MidiDeviceType.ble) {
           match = candidate;
           break;
         }
@@ -646,6 +644,13 @@ class MidiCommand {
       if (match != null) {
         _setDeviceRoute(device, _MidiDeviceRoute.platform);
         _setDeviceRoute(match, _MidiDeviceRoute.platform);
+        // A concurrent devices() refresh may have routed this id already,
+        // but routing alone does not open the platform endpoint; skip the
+        // connect only when the platform reports it live.
+        if (match.connected) {
+          _log('Handoff: CoreMIDI endpoint already connected for ${device.id}');
+          return;
+        }
         try {
           await _platform.connectToDevice(match);
           _log('Handoff: connected CoreMIDI endpoint for ${device.id}');
@@ -658,7 +663,9 @@ class MidiCommand {
       }
       await Future<void>.delayed(pollInterval);
     }
-    _log('Handoff: timed out for ${device.id}; keeping BLE transport data path');
+    _log(
+      'Handoff: timed out for ${device.id}; keeping BLE transport data path',
+    );
   }
 
   _MidiDeviceRoute _resolveDeviceRoute(MidiDevice device) {
@@ -677,6 +684,16 @@ class MidiCommand {
     }
 
     return _MidiDeviceRoute.platform;
+  }
+
+  /// BLE transport packets, excluding devices handed off to the platform
+  /// backend (see [_handoffBleToPlatform]), whose CoreMIDI endpoint would
+  /// otherwise deliver every message a second time.
+  Stream<MidiPacket> _bleTransportPackets() {
+    return _bleTransport!.onMidiDataReceived.where(
+      (packet) =>
+          _deviceRouteById[packet.device.id] != _MidiDeviceRoute.platform,
+    );
   }
 
   Stream<MidiDataReceivedEvent> _mapPacketsToTypedEvents(

--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -392,8 +392,25 @@ class _BleMidiDevice extends MidiDevice {
       return;
     }
 
-    final isPaired = await UniversalBle.isPaired(deviceId) ?? false;
-    if (isPaired) {
+    final isPaired = await UniversalBle.isPaired(deviceId);
+    if (isPaired ?? false) {
+      _devState = _DeviceState.available;
+      _startNotify();
+      return;
+    }
+    // Platforms without a system pairing API (Apple, web) return null and
+    // never fire onPairingStateChange, so notifications would never start.
+    // Read the MIDI characteristic once (per the BLE MIDI spec; triggers OS
+    // pairing when encryption is required) and subscribe directly.
+    if (isPaired == null) {
+      try {
+        await UniversalBle.read(
+          deviceId,
+          _midiService!.uuid,
+          _midiCharacteristic!.uuid,
+          timeout: const Duration(seconds: 5),
+        );
+      } catch (_) {}
       _devState = _DeviceState.available;
       _startNotify();
       return;
@@ -407,13 +424,15 @@ class _BleMidiDevice extends MidiDevice {
     if (_midiService == null || _midiCharacteristic == null) {
       return;
     }
-    try {
+    // subscribeNotifications is async, so a synchronous try/catch cannot
+    // catch its errors; swallow them explicitly instead.
+    unawaited(
       UniversalBle.subscribeNotifications(
         deviceId,
         _midiService!.uuid,
         _midiCharacteristic!.uuid,
-      );
-    } catch (_) {}
+      ).catchError((Object _) {}),
+    );
   }
 
   void handleData(Uint8List data) {

--- a/test/flutter_midi_command_test.dart
+++ b/test/flutter_midi_command_test.dart
@@ -478,6 +478,51 @@ void main() {
     },
   );
 
+  test('BLE transport packets are suppressed for devices routed to the '
+      'platform backend', () async {
+    final platform = _FakePlatformWithBleHost();
+    final ble = _FakeBleTransport();
+    MidiCommand.setPlatformOverride(platform);
+    final midi = MidiCommand(bleTransport: ble);
+
+    // Routes host-ble-1 to the platform backend.
+    await midi.devices;
+
+    final received = <MidiDataReceivedEvent>[];
+    final sub = midi.onMidiDataReceived!.listen(received.add);
+
+    // The same peripheral seen through both paths (e.g. after the CoreMIDI
+    // handoff); only the platform copy should surface.
+    ble.emitPacket(
+      MidiPacket(
+        Uint8List.fromList([0x90, 0x3C, 0x64]),
+        1,
+        MidiDevice('host-ble-1', 'Host BLE', MidiDeviceType.ble, true),
+      ),
+    );
+    platform.emitPacket(
+      MidiPacket(
+        Uint8List.fromList([0x90, 0x3C, 0x64]),
+        2,
+        MidiDevice('host-ble-1', 'Host BLE', MidiDeviceType.ble, true),
+      ),
+    );
+    // A device still owned by the BLE transport is unaffected.
+    ble.emitPacket(
+      MidiPacket(
+        Uint8List.fromList([0x80, 0x3C, 0x00]),
+        3,
+        MidiDevice('ble-1', 'BLE', MidiDeviceType.ble, true),
+      ),
+    );
+
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    await sub.cancel();
+
+    expect(received.length, 2);
+    expect(received.map((event) => event.timestamp), containsAll(<int>[2, 3]));
+  });
+
   test('sendData does not fan out to BLE when BLE transport is excluded', () {
     final platform = _FakePlatform();
     final ble = _FakeBleTransport();


### PR DESCRIPTION
## Symptom

On iOS with 1.0.2 and `UniversalBleMidiTransport`, a BLE MIDI peripheral that CoreMIDI never surfaces connects successfully but never delivers a single MIDI message. Affected peripherals are typically ones whose MIDI I/O characteristic does not require encryption, so iOS never bonds them and the OS BLE-MIDI driver never creates a CoreMIDI device for them. Reproduced with a [JamCorder](https://www.jamcorder.com/) BLE MIDI adapter; a Yamaha P-525 (bonded, so present in CoreMIDI) works because it takes the platform route directly.

## Root cause

Two defects combine to leave no working data path:

1. **`flutter_midi_command_ble` never subscribes to notifications on Apple/web.** `_discoverServices` gates `_startNotify()` on a pairing confirmation, but `universal_ble` has no system pairing API there: `isPaired` returns null (treated as "not paired") and `onPairingStateChange` only fires from a Dart-side path that requires a `pairingCommand` the transport never passes. `_startNotify()` is unreachable, making the transport's data path dead code on those platforms.
2. **The BLE-to-CoreMIDI handoff requires the peripheral to appear in CoreMIDI within 20s.** For never-bonded peripherals it never appears; the handoff times out "keeping BLE transport data path" — which is the dead path from (1).

Log from an affected connection (with `logHandler` wired up):

```
Handoff: waiting for CoreMIDI counterpart of 712629B6-...
Handoff: timed out for 712629B6-...; keeping BLE transport data path
```

with the device never appearing in the platform device list.

## Fix

- **flutter_midi_command_ble**: when `isPaired` returns null, read the MIDI I/O characteristic once (per the BLE MIDI spec; also triggers OS pairing when encryption is required) and subscribe to notifications directly. Platforms with a real pairing API (Android, Windows, Linux) are unchanged.
- **flutter_midi_command**: with the BLE path live, a handed-off device would double-deliver (CoreMIDI + BLE subscription). BLE-transport packets are now suppressed for devices routed to the platform backend, keeping the handed-off CoreMIDI endpoint authoritative. The handoff also now connects the endpoint even when a concurrent `devices()` refresh already flipped the route, since routing alone never opens the endpoint. Existing behavior is unchanged on platforms without a CoreMIDI counterpart, and for peripherals the OS never surfaces, the BLE subscription simply remains the data path after the handoff times out.

## Testing

- `flutter analyze` and `flutter test` pass in both packages (74 + 5 tests), including a new test covering the duplicate suppression.
- Hardware-verified on iPhone (iOS): JamCorder (never in CoreMIDI) streams notes immediately on a fresh connect over the BLE notify path; Yamaha P-525 direct (bonded, platform route) unchanged; switching between the two repeatedly works with no duplicate delivery.

## Reviewer note

The handoff race fix slightly changes the bond-during-session flow (first-time pairing of an encryption-requiring peripheral): the handoff now always opens the CoreMIDI endpoint unless the platform already reports it connected, instead of returning early once the route flips. I could not exercise that flow on hardware, so extra eyes there are welcome.
