### PR TITLE
fix: export MidiPairingInfoRemovedException

### DIFF
--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -18,6 +18,7 @@ export 'package:flutter_midi_command_platform_interface/flutter_midi_command_pla
         MidiNotificationSubscriptionException,
         MidiPacket,
         MidiPairingFailedException,
+        MidiPairingInfoRemovedException,
         MidiPairingRejectedException,
         MidiPort,
         MidiServiceDiscoveryException,


### PR DESCRIPTION
#161 introduced `MidiPairingInfoRemovedException`, thrown from the BLE transport when iOS reports `CBErrorPeerRemovedPairingInformation`, but the new type wasn't added to `flutter_midi_command`'s export list. Apps depending only on the main package can't catch it by name, even though this is the exact case where an app wants to show specific guidance ("forget the device in Bluetooth settings, then reconnect"). Instead, they have to fall back to matching the base `MidiConnectionException`.

This adds the type to the existing `show` combinator.

Found while adopting the typed exception hierarchy in an app that migrated from 1.0.2 to 1.0.6. Thanks for the staged-connect and teardown work in #161, it let us delete a pile of downstream defensive code.