### PR TITLE
Fix android kotlin incremental cache 163

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+ - FIX(android): disable Kotlin incremental compilation for the Android implementation so Windows builds do not fail when the app project and Pub cache are on different drives (#163).
+
 ## 1.0.7
 
  - FIX: export `MidiPairingInfoRemovedException` from `package:flutter_midi_command/flutter_midi_command.dart`.

--- a/packages/flutter_midi_command_android/CHANGELOG.md
+++ b/packages/flutter_midi_command_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+ - FIX(android): disable Kotlin incremental compilation for the Android plugin on Windows hosts to avoid Kotlin cache failures when the app project and Pub cache are on different drives (#163).
+
 ## 1.0.7
 
  - Bump "flutter_midi_command_android" to `1.0.7` and update the platform interface dependency constraint.

--- a/packages/flutter_midi_command_android/android/gradle.properties
+++ b/packages/flutter_midi_command_android/android/gradle.properties
@@ -1,0 +1,3 @@
+# Work around Kotlin/Gradle incremental cache path failures when this plugin is
+# built from a Pub cache on a different Windows drive than the app project.
+kotlin.incremental=false

--- a/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
+++ b/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
@@ -28,6 +28,7 @@ class _FakePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {
     updateConnection(deviceId, true);
   }

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -64,6 +64,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {
     connectCalls.add(deviceId);
     await Future<void>.delayed(const Duration(milliseconds: 1));


### PR DESCRIPTION
Fixes #163.

Disables Kotlin incremental compilation for the Android plugin by adding
`kotlin.incremental=false` to the plugin Android Gradle properties.

This works around Kotlin/Gradle cache failures on Windows when the consuming
Flutter project and Pub cache are on different drive roots, for example app on
`D:` and Pub cache on `C:`.