### PR TITLE
Fix Darwin MIDI port direction mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+ - FIX(darwin): report CoreMIDI destinations as `inputPorts` and sources as `outputPorts` so port direction matches Android and the public device-owned API contract (#164).
  - FIX(android): disable Kotlin incremental compilation for the Android implementation so Windows builds do not fail when the app project and Pub cache are on different drives (#163).
 
 ## 1.0.7

--- a/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
+++ b/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
@@ -28,6 +28,7 @@ class _FakePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {
     updateConnection(deviceId, true);
   }

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -64,6 +64,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
     String deviceId, {
     Duration? connectionTimeout,
     bool autoConnect = false,
+    ConnectionPlatformConfig? platformConfig,
   }) async {
     connectCalls.add(deviceId);
     await Future<void>.delayed(const Duration(milliseconds: 1));
@@ -399,10 +400,11 @@ void main() {
 
   test('connectToDevice makes registered known BLE device visible', () async {
     fakePlatform.servicesByDevice['ble-known-connect'] = midiServices();
-    final registered = transport.registerKnownDevice(
-      'ble-known-connect',
-      'Known Connect Device',
-    )!;
+    final registered =
+        transport.registerKnownDevice(
+          'ble-known-connect',
+          'Known Connect Device',
+        )!;
 
     expect(await transport.devices, isEmpty);
 


### PR DESCRIPTION
Fixes #164.

Darwin now reports CoreMIDI destinations as `inputPorts` and CoreMIDI sources as `outputPorts`, matching the public device-owned port direction contract used by Android.

Also updates explicit port selection on Darwin so selected public ports still map back to the correct CoreMIDI source/destination internally.