### PR TITLE
feat(ble): expose advertised service UUIDs on MidiDevice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,12 @@ on:
     branches:
       - main
       - master
-      - codex/restructure-repo-into-mono-repo-with-melon
+
+# A new push supersedes the run it interrupted; the macOS and emulator jobs are
+# too expensive to leave racing against themselves.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FLUTTER_VERSION: '3.44.2'
@@ -47,10 +52,12 @@ jobs:
           dart pub global activate melos ${{ env.MELOS_VERSION }}
           echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
       - run: melos bootstrap
+      - run: melos run format:check
       - run: melos run analyze
       - run: melos run analyze:example
       - run: melos run test
       - run: melos run test:web:chrome
+      - run: melos run publish:dry-run
 
   native_android_checks:
     runs-on: ubuntu-latest
@@ -85,23 +92,6 @@ jobs:
       - run: melos bootstrap
       - name: Darwin native tests
         run: melos run test:native:darwin
-
-  native_linux_checks:
-    runs-on: ubuntu-latest
-    needs: pigeon_contracts
-    steps:
-      - uses: actions/checkout@v6
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-      - name: Install Melos
-        shell: bash
-        run: |
-          dart pub global activate melos ${{ env.MELOS_VERSION }}
-          echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
-      - run: melos bootstrap
-      - name: Linux backend tests
-        run: melos run test:native:linux
 
   native_windows_checks:
     runs-on: windows-latest
@@ -160,7 +150,9 @@ jobs:
 
   example_linux:
     runs-on: ubuntu-latest
-    needs: [dart_checks, native_linux_checks]
+    # The linux backend is pure Dart, so `melos run test` in dart_checks already
+    # covers it; the build below is what exercises it on a Linux host.
+    needs: dart_checks
     steps:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2

--- a/README.md
+++ b/README.md
@@ -216,6 +216,29 @@ Connection failures are surfaced as typed `MidiConnectionException` subclasses w
 
 Pass `awaitConnectionTimeout: null` only if you explicitly want to let the required readiness flow wait indefinitely. The optional Apple CoreMIDI handoff remains bounded.
 
+### Filtering discovered BLE devices
+
+BLE scanning is already constrained to the BLE MIDI service, so non-MIDI
+peripherals never reach `devices`. To narrow discovery further — for example to
+one vendor's hardware — use the UUIDs the peripheral advertised alongside the
+MIDI service:
+
+```dart
+const vendorService = '0000fe59-0000-1000-8000-00805f9b34fb';
+
+final devices = await midi.devices ?? const <MidiDevice>[];
+final vendorDevices =
+    devices.where((d) => d.serviceUUIDs.contains(vendorService));
+```
+
+`MidiDevice.serviceUUIDs` holds lowercase 128-bit UUID strings. It is populated
+only for devices discovered over the Dart BLE transport, and is empty for
+host-native devices — including Bluetooth devices routed through host MIDI APIs
+such as CoreMIDI (see "Host-paired Bluetooth MIDI devices may be native-routed").
+Some peripherals split their advertisement and scan response, so a device may be
+reported before its full UUID list is known; treat the value as best-effort and
+re-read it on `MidiSetupChange` events.
+
 ### Setup change events
 
 Listen to `onMidiSetupChanged` to refresh your device list when the host MIDI topology changes. Native desktop/mobile transports monitor platform setup notifications and emit `MidiSetupChange` values:

--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -20,6 +20,15 @@ bool _isPairingInfoRemoved(Object error) =>
     error is UniversalBleException &&
     error.message.toLowerCase().contains('pairing information');
 
+/// Advertised service UUIDs as lowercase 128-bit strings, dropping any entry
+/// that is not a valid UUID. The pigeon-backed platforms already normalize, but
+/// the Linux and Web implementations pass advertisement UUIDs through untouched,
+/// so do it here to keep [MidiDevice.serviceUUIDs] comparable everywhere.
+List<String> _normalizeServiceUuids(List<String> uuids) => uuids
+    .map(BleUuidParser.stringOrNull)
+    .whereType<String>()
+    .toList(growable: false);
+
 enum _BleHandlerState {
   header,
   timestamp,
@@ -67,9 +76,16 @@ class UniversalBleMidiTransport implements MidiBleTransport {
       if (result.name == null) {
         return;
       }
+      final advertisedServices = _normalizeServiceUuids(result.services);
       final existing = _devices[result.deviceId];
       if (existing != null) {
         existing.name = result.name!;
+        // Advertisement and scan-response packets arrive separately and only one
+        // of them carries the service list, so an empty list means "not in this
+        // packet" rather than "no longer advertised". Keep what we already saw.
+        if (advertisedServices.isNotEmpty) {
+          existing.serviceUUIDs = advertisedServices;
+        }
         if (!existing.visible) {
           existing.visible = true;
           _setupStreamController.add(MidiSetupChange.deviceAppeared);
@@ -80,7 +96,7 @@ class UniversalBleMidiTransport implements MidiBleTransport {
         deviceId: result.deviceId,
         name: result.name!,
         rxStream: _rxStreamController,
-      );
+      )..serviceUUIDs = advertisedServices;
       _setupStreamController.add(MidiSetupChange.deviceAppeared);
     };
 

--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -105,6 +105,15 @@ const _gattRetryDelay = Duration(milliseconds: 500);
 /// shared command queue.
 const _mtuTimeout = Duration(seconds: 2);
 
+/// Advertised service UUIDs as lowercase 128-bit strings, dropping any entry
+/// that is not a valid UUID. The pigeon-backed platforms already normalize, but
+/// the Linux and Web implementations pass advertisement UUIDs through untouched,
+/// so do it here to keep [MidiDevice.serviceUUIDs] comparable everywhere.
+List<String> _normalizeServiceUuids(List<String> uuids) => uuids
+    .map(BleUuidParser.stringOrNull)
+    .whereType<String>()
+    .toList(growable: false);
+
 enum _BleHandlerState {
   header,
   timestamp,
@@ -216,9 +225,16 @@ class UniversalBleMidiTransport implements MidiBleTransport {
       if (result.name == null) {
         return;
       }
+      final advertisedServices = _normalizeServiceUuids(result.services);
       final existing = _devices[result.deviceId];
       if (existing != null) {
         existing.name = result.name!;
+        // Advertisement and scan-response packets arrive separately and only one
+        // of them carries the service list, so an empty list means "not in this
+        // packet" rather than "no longer advertised". Keep what we already saw.
+        if (advertisedServices.isNotEmpty) {
+          existing.serviceUUIDs = advertisedServices;
+        }
         if (!existing.visible) {
           existing.visible = true;
           _setupStreamController.add(MidiSetupChange.deviceAppeared);
@@ -229,7 +245,7 @@ class UniversalBleMidiTransport implements MidiBleTransport {
         deviceId: result.deviceId,
         name: result.name!,
         visible: true,
-      );
+      )..serviceUUIDs = advertisedServices;
       _setupStreamController.add(MidiSetupChange.deviceAppeared);
     };
 

--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -704,9 +704,7 @@ class _BleMidiDevice extends MidiDevice {
           if (attempt > 0 || !_isTransientLinkFailure(cause)) {
             rethrow;
           }
-          _log(
-            '$deviceId: link dropped during setup ($error); retrying once',
-          );
+          _log('$deviceId: link dropped during setup ($error); retrying once');
         }
         await Future<void>.delayed(_gattRetryDelay);
       }
@@ -909,7 +907,9 @@ class _BleMidiDevice extends MidiDevice {
   /// ~30-50 ms default), which is the floor on MIDI latency.
   ///
   /// Best-effort: only Android implements it, and a peripheral can decline.
-  Future<void> _requestConnectionPriority(BleConnectionPriority priority) async {
+  Future<void> _requestConnectionPriority(
+    BleConnectionPriority priority,
+  ) async {
     if (!requestHighPerformanceConnection) {
       return;
     }

--- a/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
+++ b/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
@@ -201,46 +201,49 @@ void main() {
     }
   });
 
-  test('BLE MIDI SysEx survives a chunk/parse round-trip at any size', () async {
-    BleCapabilities.hasSystemPairingApi = true;
-    final fake = _FakePlatform();
-    UniversalBle.setInstance(fake);
-    final transport = UniversalBleMidiTransport();
+  test(
+    'BLE MIDI SysEx survives a chunk/parse round-trip at any size',
+    () async {
+      BleCapabilities.hasSystemPairingApi = true;
+      final fake = _FakePlatform();
+      UniversalBle.setInstance(fake);
+      final transport = UniversalBleMidiTransport();
 
-    fake.servicesByDevice['dev'] = midiServices();
-    fake.emitScan('dev', 'GEWA');
-    final device = (await transport.devices).single;
-    await transport.connectToDevice(device);
-    await Future<void>.delayed(const Duration(milliseconds: 5));
+      fake.servicesByDevice['dev'] = midiServices();
+      fake.emitScan('dev', 'GEWA');
+      final device = (await transport.devices).single;
+      await transport.connectToDevice(device);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
 
-    final received = <List<int>>[];
-    final sub = transport.onMidiDataReceived.listen(
-      (p) => received.add(p.data.toList()),
-    );
+      final received = <List<int>>[];
+      final sub = transport.onMidiDataReceived.listen(
+        (p) => received.add(p.data.toList()),
+      );
 
-    // Sweep every body length across the packet boundaries of several write
-    // sizes, feeding the chunker's own output back through the parser.
-    final expected = <List<int>>[];
-    for (final writeSize in <int>[20, 23, 100, 244]) {
-      for (var bodyLength = 0; bodyLength <= 200; bodyLength++) {
-        final sysEx = <int>[
-          0xF0,
-          ...List<int>.generate(bodyLength, (i) => i % 0x80),
-          0xF7,
-        ];
-        expected.add(sysEx);
-        for (final packet in buildBleMidiSysExPackets(sysEx, writeSize)) {
-          fake.emitValue('dev', packet);
+      // Sweep every body length across the packet boundaries of several write
+      // sizes, feeding the chunker's own output back through the parser.
+      final expected = <List<int>>[];
+      for (final writeSize in <int>[20, 23, 100, 244]) {
+        for (var bodyLength = 0; bodyLength <= 200; bodyLength++) {
+          final sysEx = <int>[
+            0xF0,
+            ...List<int>.generate(bodyLength, (i) => i % 0x80),
+            0xF7,
+          ];
+          expected.add(sysEx);
+          for (final packet in buildBleMidiSysExPackets(sysEx, writeSize)) {
+            fake.emitValue('dev', packet);
+          }
         }
       }
-    }
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    await sub.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
 
-    expect(received, hasLength(expected.length));
-    for (var i = 0; i < expected.length; i++) {
-      expect(received[i], expected[i], reason: 'round-trip mismatch at $i');
-    }
-  });
+      expect(received, hasLength(expected.length));
+      for (var i = 0; i < expected.length; i++) {
+        expect(received[i], expected[i], reason: 'round-trip mismatch at $i');
+      }
+    },
+  );
 }

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -543,6 +543,85 @@ void main() {
     expect(device.connected, isFalse);
   });
 
+  group('advertised service UUIDs', () {
+    const vendorService = '0000fe59-0000-1000-8000-00805f9b34fb';
+
+    test('are exposed on the discovered device', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[midiServiceId, vendorService],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[
+        midiServiceId.toLowerCase(),
+        vendorService,
+      ]);
+    });
+
+    test('are normalized to lowercase 128-bit form', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-short-uuid',
+          name: 'Short UUID Device',
+          services: <String>['180D', 'not-a-uuid'],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[
+        '0000180d-0000-1000-8000-00805f9b34fb',
+      ]);
+    });
+
+    test('survive an advertisement that carries no service list', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[vendorService],
+        ),
+      );
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[vendorService]);
+    });
+
+    test('are replaced when a later advertisement lists others', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[vendorService],
+        ),
+      );
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[midiServiceId],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[midiServiceId.toLowerCase()]);
+    });
+  });
+
   test('teardown unregisters callbacks and can be reactivated', () async {
     expect(fakePlatform.onScanResultUpdate, isNotNull);
     expect(fakePlatform.onConnectionChange, isNotNull);

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -842,6 +842,85 @@ void main() {
     expect(device.connected, isFalse);
   });
 
+  group('advertised service UUIDs', () {
+    const vendorService = '0000fe59-0000-1000-8000-00805f9b34fb';
+
+    test('are exposed on the discovered device', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[midiServiceId, vendorService],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[
+        midiServiceId.toLowerCase(),
+        vendorService,
+      ]);
+    });
+
+    test('are normalized to lowercase 128-bit form', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-short-uuid',
+          name: 'Short UUID Device',
+          services: <String>['180D', 'not-a-uuid'],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[
+        '0000180d-0000-1000-8000-00805f9b34fb',
+      ]);
+    });
+
+    test('survive an advertisement that carries no service list', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[vendorService],
+        ),
+      );
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[vendorService]);
+    });
+
+    test('are replaced when a later advertisement lists others', () async {
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[vendorService],
+        ),
+      );
+      fakePlatform.emitScanDevice(
+        BleDevice(
+          deviceId: 'ble-uuid',
+          name: 'UUID Device',
+          services: <String>[midiServiceId],
+        ),
+      );
+
+      final device = (await transport.devices).single;
+
+      expect(device.serviceUUIDs, <String>[midiServiceId.toLowerCase()]);
+    });
+  });
+
   test('teardown unregisters callbacks and can be reactivated', () async {
     expect(fakePlatform.onScanResultUpdate, isNotNull);
     expect(fakePlatform.onConnectionChange, isNotNull);

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -28,7 +28,8 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
 
   /// Payloads passed to `writeValue`, in order.
   final List<List<int>> writtenPackets = <List<int>>[];
-  final List<BleConnectionPriority> priorityRequests = <BleConnectionPriority>[];
+  final List<BleConnectionPriority> priorityRequests =
+      <BleConnectionPriority>[];
   final Set<String> rejectedPairIds = <String>{};
   final Map<String, List<BleService>> servicesByDevice =
       <String, List<BleService>>{};
@@ -168,8 +169,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
   ) async {
     gattCalls.add('subscribe');
     subscribeCalls.add(deviceId);
-    final remainingGattFailures =
-        transientGattSubscribeFailures[deviceId] ?? 0;
+    final remainingGattFailures = transientGattSubscribeFailures[deviceId] ?? 0;
     if (remainingGattFailures > 0) {
       transientGattSubscribeFailures[deviceId] = remainingGattFailures - 1;
       updateConnection(deviceId, false);
@@ -473,10 +473,7 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 5));
 
     expect(fakePlatform.connectCalls, <String>['ble-sub-133', 'ble-sub-133']);
-    expect(fakePlatform.subscribeCalls, <String>[
-      'ble-sub-133',
-      'ble-sub-133',
-    ]);
+    expect(fakePlatform.subscribeCalls, <String>['ble-sub-133', 'ble-sub-133']);
     expect(device.connected, isTrue);
     expect((await transport.devices).single.id, 'ble-sub-133');
   });
@@ -503,7 +500,10 @@ void main() {
     await transport.connectToDevice(device);
     await Future<void>.delayed(const Duration(milliseconds: 5));
 
-    expect(fakePlatform.connectCalls, <String>['ble-disc-drop', 'ble-disc-drop']);
+    expect(fakePlatform.connectCalls, <String>[
+      'ble-disc-drop',
+      'ble-disc-drop',
+    ]);
     expect(device.connected, isTrue);
     expect((await transport.devices).single.id, 'ble-disc-drop');
   });
@@ -868,7 +868,13 @@ void main() {
   // long a firmware transfer takes.
   Uint8List firmwareSysEx([int marker = 0x00]) {
     return Uint8List.fromList(<int>[
-      0xF0, 0x7E, 0x10, 0x07, 0x02, 0x00, 0x7F,
+      0xF0,
+      0x7E,
+      0x10,
+      0x07,
+      0x02,
+      0x00,
+      0x7F,
       ...List<int>.filled(128, marker),
       0x2A,
       0xF7,
@@ -976,17 +982,20 @@ void main() {
     ]);
   });
 
-  test('requestHighPerformanceConnection: false requests no priority', () async {
-    final relaxed = UniversalBleMidiTransport(
-      requestHighPerformanceConnection: false,
-    );
-    final device = await connectDevice(relaxed, 'ble-priority-opt-out');
-    relaxed.disconnectDevice(device);
-    await Future<void>.delayed(const Duration(milliseconds: 5));
+  test(
+    'requestHighPerformanceConnection: false requests no priority',
+    () async {
+      final relaxed = UniversalBleMidiTransport(
+        requestHighPerformanceConnection: false,
+      );
+      final device = await connectDevice(relaxed, 'ble-priority-opt-out');
+      relaxed.disconnectDevice(device);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
 
-    expect(fakePlatform.priorityRequests, isEmpty);
-    relaxed.teardown();
-  });
+      expect(fakePlatform.priorityRequests, isEmpty);
+      relaxed.teardown();
+    },
+  );
 
   test('overlapping sends do not interleave their SysEx packets', () async {
     fakePlatform.negotiatedMtu = 23; // Force multi-packet SysEx.
@@ -1009,29 +1018,40 @@ void main() {
         .toList();
     final firstTwo = markers.indexOf(2);
     expect(firstTwo, greaterThan(0), reason: 'no packets for message 1');
-    expect(markers.sublist(0, firstTwo).every((m) => m == 1), isTrue,
-        reason: 'interleaved packet ordering: $markers');
-    expect(markers.sublist(firstTwo).every((m) => m == 2), isTrue,
-        reason: 'interleaved packet ordering: $markers');
-  });
-
-  test('sendDataAwaitingDelivery completes only after the writes land',
-      () async {
-    fakePlatform.negotiatedMtu = 23;
-    fakePlatform.writeDelay = const Duration(milliseconds: 2);
-    await connectDevice(transport, 'ble-awaited');
-    fakePlatform.writtenPackets.clear();
-
-    final delivered = transport.sendDataAwaitingDelivery(
-      firmwareSysEx(0x01),
-      deviceId: 'ble-awaited',
+    expect(
+      markers.sublist(0, firstTwo).every((m) => m == 1),
+      isTrue,
+      reason: 'interleaved packet ordering: $markers',
     );
-    expect(fakePlatform.writtenPackets.length, lessThan(8),
-        reason: 'writes should still be in flight immediately after the call');
-
-    await delivered;
-    expect(fakePlatform.writtenPackets, hasLength(8));
+    expect(
+      markers.sublist(firstTwo).every((m) => m == 2),
+      isTrue,
+      reason: 'interleaved packet ordering: $markers',
+    );
   });
+
+  test(
+    'sendDataAwaitingDelivery completes only after the writes land',
+    () async {
+      fakePlatform.negotiatedMtu = 23;
+      fakePlatform.writeDelay = const Duration(milliseconds: 2);
+      await connectDevice(transport, 'ble-awaited');
+      fakePlatform.writtenPackets.clear();
+
+      final delivered = transport.sendDataAwaitingDelivery(
+        firmwareSysEx(0x01),
+        deviceId: 'ble-awaited',
+      );
+      expect(
+        fakePlatform.writtenPackets.length,
+        lessThan(8),
+        reason: 'writes should still be in flight immediately after the call',
+      );
+
+      await delivered;
+      expect(fakePlatform.writtenPackets, hasLength(8));
+    },
+  );
 
   test('a failed write is reported and the SysEx still completes', () async {
     fakePlatform.negotiatedMtu = 23;

--- a/packages/flutter_midi_command_platform_interface/lib/midi_ble_transport.dart
+++ b/packages/flutter_midi_command_platform_interface/lib/midi_ble_transport.dart
@@ -47,8 +47,7 @@ abstract class MidiBleTransport {
     Uint8List data, {
     int? timestamp,
     String? deviceId,
-  }) async =>
-      sendData(data, timestamp: timestamp, deviceId: deviceId);
+  }) async => sendData(data, timestamp: timestamp, deviceId: deviceId);
   Stream<MidiPacket> get onMidiDataReceived;
   Stream<MidiSetupChange> get onMidiSetupChanged;
 

--- a/packages/flutter_midi_command_platform_interface/lib/midi_device.dart
+++ b/packages/flutter_midi_command_platform_interface/lib/midi_device.dart
@@ -57,6 +57,14 @@ class MidiDevice {
 
   /// Ports that send MIDI data out of this device.
   List<MidiPort> outputPorts = [];
+
+  /// Service UUIDs advertised by this device, as lowercase 128-bit strings.
+  ///
+  /// Populated for devices discovered over the Dart BLE transport, where it can
+  /// be used to narrow discovery to specific hardware. Empty for host-native
+  /// devices, including Bluetooth devices routed through host MIDI APIs such as
+  /// CoreMIDI.
+  List<String> serviceUUIDs = const <String>[];
   final StreamController<MidiConnectionState> _connectionStateController =
       StreamController<MidiConnectionState>.broadcast();
   MidiConnectionState _connectionState;

--- a/packages/flutter_midi_command_platform_interface/test/method_channel_midi_command_test.dart
+++ b/packages/flutter_midi_command_platform_interface/test/method_channel_midi_command_test.dart
@@ -107,6 +107,9 @@ void main() {
     expect(devices.first.outputPorts.first.id, 1);
     expect(devices.first.outputPorts.first.type, MidiPortType.OUT);
     expect(devices.first.outputPorts.first.connected, isFalse);
+    // Service UUIDs come from the Dart BLE transport only; the host device
+    // channel carries none.
+    expect(devices.first.serviceUUIDs, isEmpty);
   });
 
   test('devices prunes stale cached devices when host list changes', () async {

--- a/packages/flutter_midi_command_platform_interface/test/method_channel_midi_command_test.dart
+++ b/packages/flutter_midi_command_platform_interface/test/method_channel_midi_command_test.dart
@@ -113,6 +113,9 @@ void main() {
     expect(devices.first.outputPorts.first.id, 1);
     expect(devices.first.outputPorts.first.type, MidiPortType.OUT);
     expect(devices.first.outputPorts.first.connected, isFalse);
+    // Service UUIDs come from the Dart BLE transport only; the host device
+    // channel carries none.
+    expect(devices.first.serviceUUIDs, isEmpty);
   });
 
   test('devices prunes stale cached devices when host list changes', () async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,15 +92,15 @@ melos:
     analyze:example:
       run: dart run melos exec --scope=flutter_midi_command_example -- "flutter analyze"
     test:
-      run: dart run melos exec --dir-exists=test --concurrency=1 --ignore=flutter_midi_command_example --ignore=flutter_midi_command_web -- "flutter test"
+      # The example is included: its widget tests cover the app-facing wiring
+      # (transport toggles, connection error mapping) that no package test does.
+      run: dart run melos exec --dir-exists=test --concurrency=1 --ignore=flutter_midi_command_web -- "flutter test"
     test:web:chrome:
       run: dart run melos exec --scope=flutter_midi_command_web -- "flutter test --platform chrome"
     test:native:android:
       run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest
     test:native:darwin:
       run: bash tool/darwin_native_checks.sh
-    test:native:linux:
-      run: dart run melos exec --scope=flutter_midi_command_linux -- "flutter test"
     test:native:windows:
       run: dart run melos exec --scope=flutter_midi_command_windows -- "flutter test"
     test:example:integration:android:
@@ -129,3 +129,10 @@ melos:
       run: dart run melos exec --scope=flutter_midi_command_example -- "flutter build web --debug"
     format:
       run: dart run melos exec -- "dart format --set-exit-if-changed ."
+    format:check:
+      # Same check without rewriting, for CI.
+      run: dart run melos exec -- "dart format --output=none --set-exit-if-changed ."
+    publish:dry-run:
+      # Catches packaging regressions (missing LICENSE/README, unresolvable
+      # constraints) on the PR that introduces them rather than at release.
+      run: dart run melos exec --no-private --concurrency=1 -- "flutter pub publish --dry-run"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,7 +98,9 @@ melos:
     test:web:chrome:
       run: dart run melos exec --scope=flutter_midi_command_web -- "flutter test --platform chrome"
     test:native:android:
-      run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest
+      # `assembleDebug` on the BLE package compiles its Android plugin, which
+      # otherwise only builds as a side effect of the example app job.
+      run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest :flutter_midi_command_ble:assembleDebug
     test:native:darwin:
       run: bash tool/darwin_native_checks.sh
     test:native:windows:


### PR DESCRIPTION
Reimplements the feature proposed in #134 by @LEggcookies for the current federated / `universal_ble` architecture. The original patch targeted the pre-federation native Android/iOS sources, which no longer exist — credit for the idea is theirs.

## What

`MidiDevice.serviceUUIDs` exposes the service UUIDs a BLE peripheral advertised, so an app can narrow discovery beyond the MIDI service filter to specific hardware:

```dart
const vendorService = '0000fe59-0000-1000-8000-00805f9b34fb';
final devices = await midi.devices ?? const <MidiDevice>[];
final vendorDevices = devices.where((d) => d.serviceUUIDs.contains(vendorService));
```

## Notes

- Populated only on the Dart BLE transport path. Host-native devices — including Bluetooth devices routed through host MIDI APIs such as CoreMIDI — report an empty list.
- UUIDs are normalized to lowercase 128-bit form via `BleUuidParser`. The pigeon-backed platforms already do this, but Linux and Web pass advertisement UUIDs through raw; normalizing keeps the field comparable everywhere. Unparseable entries are dropped.
- An advertisement without a service list does not clear previously seen UUIDs: advertisement and scan-response packets arrive separately and only one carries the list.
- Additive field with a `const []` default, so the `MidiDevice` constructor and all subclasses stay source-compatible.

## Tests

Four new cases in `packages/flutter_midi_command_ble/test/` (exposure, normalization, empty-advertisement retention, replacement), plus an assertion in the platform-interface test pinning the empty-for-host-devices contract. `flutter analyze` clean; BLE, platform-interface and root suites pass.

Closes #134