### PR TITLE
fix(ble): stop the MTU request from stalling Android connects (GATT 133)

### DIFF
--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -20,6 +20,25 @@ bool _isPairingInfoRemoved(Object error) =>
     error is UniversalBleException &&
     error.message.toLowerCase().contains('pairing information');
 
+/// True when [error] is Android's generic `GATT_ERROR` (0x85 / 133). The
+/// Android stack returns it for almost any connection that failed or was
+/// dropped during the handshake, and universal_ble has no HCI name for it, so
+/// it arrives as `UniversalBleException(unknownError, "Unknown Error 133")`.
+/// It is usually transient: the stack has torn the GATT client down and a
+/// second attempt, after a short settle, succeeds.
+bool _isTransientGattError(Object error) =>
+    error is UniversalBleException &&
+    error.message.contains('Unknown Error 133');
+
+/// How long to let the Android stack settle before retrying through a
+/// [_isTransientGattError] failure.
+const _gattRetryDelay = Duration(milliseconds: 500);
+
+/// Cap on the opportunistic MTU exchange. Well under the 10 s global
+/// universal_ble timeout so a peripheral that never answers cannot hold the
+/// shared command queue.
+const _mtuTimeout = Duration(seconds: 2);
+
 enum _BleHandlerState {
   header,
   timestamp,
@@ -240,6 +259,11 @@ class UniversalBleMidiTransport implements MidiBleTransport {
         );
     try {
       await bleDevice.connect(timeout: timeout);
+      // A connection attempt that dropped before succeeding (an Android GATT
+      // 133 we retried through) reports a disconnect, which evicts the device
+      // from the cache. Put it back, or incoming data and by-id sends would
+      // have nothing to resolve to.
+      _devices[bleDevice.deviceId] = bleDevice;
       bleDevice.visible = true;
       if (!identical(bleDevice, device)) {
         device.connected = bleDevice.connected;
@@ -352,7 +376,6 @@ class _BleMidiDevice extends MidiDevice {
       return;
     }
 
-    unawaited(_requestMtu());
     if (!_readinessInProgress &&
         _devState.index < _DeviceState.interrogating.index) {
       unawaited(
@@ -382,11 +405,7 @@ class _BleMidiDevice extends MidiDevice {
     }
     _readinessInProgress = true;
     try {
-      await _runStage(
-        MidiConnectionStage.bluetoothConnect,
-        () => UniversalBle.connect(deviceId, timeout: timeout),
-        timeout,
-      );
+      await _connectLink(timeout: timeout);
       if (!_bleLinkConnected) {
         final connectionState = await _runStage(
           MidiConnectionStage.bluetoothConnect,
@@ -421,6 +440,32 @@ class _BleMidiDevice extends MidiDevice {
       rethrow;
     } finally {
       _readinessInProgress = false;
+    }
+  }
+
+  /// Brings up the BLE link, retrying once through a transient Android
+  /// `GATT_ERROR`. Android reports that failure only after it has already torn
+  /// its GATT client down, so the retry asks for a fresh one; the disconnect
+  /// covers the rarer case where the error arrived on a link the stack still
+  /// believes is up.
+  Future<void> _connectLink({Duration? timeout}) async {
+    for (var attempt = 0; ; attempt++) {
+      try {
+        await _runStage(
+          MidiConnectionStage.bluetoothConnect,
+          () => UniversalBle.connect(deviceId, timeout: timeout),
+          timeout,
+        );
+        return;
+      } catch (error) {
+        if (attempt > 0 || !_isTransientGattError(error)) {
+          rethrow;
+        }
+      }
+      try {
+        await UniversalBle.disconnect(deviceId);
+      } catch (_) {}
+      await Future<void>.delayed(_gattRetryDelay);
     }
   }
 
@@ -518,9 +563,14 @@ class _BleMidiDevice extends MidiDevice {
     } catch (_) {}
   }
 
+  /// Asks for a larger ATT MTU so the peripheral can pack more of a SysEx dump
+  /// into each notification. Purely opportunistic: writes stay at the 20-byte
+  /// BLE MIDI packet size regardless, peripherals may refuse or ignore the
+  /// request, and Apple manages the MTU itself. It therefore runs last and
+  /// swallows failures — an MTU exchange must never cost us a working link.
   Future<void> _requestMtu() async {
     try {
-      await UniversalBle.requestMtu(deviceId, 247);
+      await UniversalBle.requestMtu(deviceId, 247, timeout: _mtuTimeout);
     } catch (_) {}
   }
 
@@ -528,6 +578,12 @@ class _BleMidiDevice extends MidiDevice {
     await _discoverServices(timeout: timeout);
     await _ensurePaired(timeout: timeout);
     await _startNotify(timeout: timeout);
+    // Deliberately after the MIDI path is live: universal_ble runs GATT
+    // commands through one queue, so an MTU request issued on the connection
+    // callback sits in front of service discovery and can stall it — long
+    // enough on Android that the peripheral drops the link with GATT_ERROR
+    // 133 before the MIDI service is ever discovered.
+    await _requestMtu();
     _devState = _DeviceState.available;
   }
 

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -18,6 +18,13 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
   final Map<String, BleConnectionState> _connectionByDevice =
       <String, BleConnectionState>{};
 
+  /// Number of remaining `connect` attempts that fail with Android's generic
+  /// GATT_ERROR, keyed by device id.
+  final Map<String, int> transientGattFailures = <String, int>{};
+
+  /// GATT operations in the order the transport issued them.
+  final List<String> gattCalls = <String>[];
+
   final List<String> connectCalls = <String>[];
   final List<String> disconnectCalls = <String>[];
   final List<String> pairCalls = <String>[];
@@ -68,6 +75,13 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
   }) async {
     connectCalls.add(deviceId);
     await Future<void>.delayed(const Duration(milliseconds: 1));
+    final remainingGattFailures = transientGattFailures[deviceId] ?? 0;
+    if (remainingGattFailures > 0) {
+      transientGattFailures[deviceId] = remainingGattFailures - 1;
+      updateConnection(deviceId, false, 'Unknown Error 133');
+      _connectionByDevice[deviceId] = BleConnectionState.disconnected;
+      throw ConnectionException('Unknown Error 133');
+    }
     if (pairingRemovedConnectIds.contains(deviceId)) {
       updateConnection(deviceId, false, 'Peer removed pairing information');
       _connectionByDevice[deviceId] = BleConnectionState.disconnected;
@@ -97,6 +111,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
     String deviceId,
     bool withDescriptors,
   ) async {
+    gattCalls.add('discover');
     return servicesByDevice[deviceId] ?? <BleService>[];
   }
 
@@ -107,6 +122,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
     String characteristic,
     BleInputProperty bleInputProperty,
   ) async {
+    gattCalls.add('subscribe');
     subscribeCalls.add(deviceId);
     if (failingSubscribeIds.contains(deviceId)) {
       throw StateError('subscribe-failed');
@@ -138,6 +154,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
 
   @override
   Future<int> requestMtu(String deviceId, int expectedMtu) async {
+    gattCalls.add('mtu');
     return expectedMtu;
   }
 
@@ -311,6 +328,61 @@ void main() {
     expect(fakePlatform.pairCalls, <String>['ble-1']);
     expect(fakePlatform.subscribeCalls, <String>['ble-1']);
     expect(device.connected, isTrue);
+  });
+
+  test('MTU negotiation runs after the MIDI path is live', () async {
+    fakePlatform.servicesByDevice['ble-mtu'] = midiServices();
+    fakePlatform.emitScanDevice(
+      BleDevice(deviceId: 'ble-mtu', name: 'MTU Device', services: <String>[]),
+    );
+
+    await transport.connectToDevice((await transport.devices).single);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    expect(fakePlatform.gattCalls, <String>['discover', 'subscribe', 'mtu']);
+  });
+
+  test('connectToDevice retries once through a transient GATT 133', () async {
+    fakePlatform.servicesByDevice['ble-133'] = midiServices();
+    fakePlatform.transientGattFailures['ble-133'] = 1;
+    fakePlatform.emitScanDevice(
+      BleDevice(
+        deviceId: 'ble-133',
+        name: 'Flaky Device',
+        services: <String>[],
+      ),
+    );
+    final device = (await transport.devices).single;
+
+    await transport.connectToDevice(device);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    expect(fakePlatform.connectCalls, <String>['ble-133', 'ble-133']);
+    expect(device.connected, isTrue);
+    // The failed attempt reported a disconnect; the device must survive it so
+    // received data still resolves to it.
+    expect((await transport.devices).single.id, 'ble-133');
+  });
+
+  test('connectToDevice gives up after one GATT 133 retry', () async {
+    fakePlatform.servicesByDevice['ble-133-hard'] = midiServices();
+    fakePlatform.transientGattFailures['ble-133-hard'] = 5;
+    fakePlatform.emitScanDevice(
+      BleDevice(
+        deviceId: 'ble-133-hard',
+        name: 'Dead Device',
+        services: <String>[],
+      ),
+    );
+    final device = (await transport.devices).single;
+
+    await expectLater(
+      transport.connectToDevice(device),
+      throwsA(isA<ConnectionException>()),
+    );
+
+    expect(fakePlatform.connectCalls, <String>['ble-133-hard', 'ble-133-hard']);
+    expect(device.connected, isFalse);
   });
 
   test('connectToDevice surfaces BLE connection failures', () async {


### PR DESCRIPTION
## Problem

Android connects fail with `UniversalBleException: Code: unknownError, Message: Unknown Error 133`. 133 is Android's generic `GATT_ERROR` (0x85); universal_ble has no HCI name for it, so `parseHciErrorCode()` falls through to `"Unknown Error $this"` and it reaches Dart untyped.

The provocation was our own MTU request. `updateConnectionState` fired `unawaited(_requestMtu())` the instant the connected callback arrived, and universal_ble delivers that callback synchronously *before* it completes the `connect()` future. Every universal_ble command shares one queue, so the MTU exchange was enqueued ahead of the service discovery `connect()` was about to issue — holding it for up to the 10 s global timeout when a peripheral answers slowly or ignores the request. That is long enough for the link to drop, which Android reports as 133.

## Changes

- MTU negotiation moved to the end of `_prepareMidiReadiness`, after discover/pair/subscribe, with its own 2 s cap. It is opportunistic anyway: writes stay at the 20-byte BLE MIDI packet size regardless and Apple manages the MTU itself, so it must never be able to cost us a working link.
- `_connectLink` retries the link once, after a 500 ms settle, when the failure is specifically a 133. Android reports it only after tearing its GATT client down, so asking for a fresh one is the recovery.
- `connectToDevice` re-inserts the device into the transport cache after a successful connect. The retry surfaced this: the failed attempt reports a disconnect that evicts the device, and without the re-insert a retried connection would come up with incoming notifications resolving to nothing.

## Testing

Three new tests cover the MTU ordering, the successful retry (including that the device survives in the cache), and giving up after one retry. Full package suite passes (23 tests) and `flutter analyze` is clean.

Deliberately **not** changed: connecting while a scan is running is the other classic 133 trigger, and universal_ble advises stopping the scan first — but that is exactly the sequence that wedges the Android LE scanner, per the known issue documented in 1.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)