### PR TITLE
fix(ble): retry a link torn down during the connection sequence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+
+ - FIX(ble): retry a connection sequence whose link was torn down mid-handshake. universal_ble reports that as `deviceDisconnected` rather than a GATT status, so the retry shipped in 1.1.1 did not apply. Unlike a GATT status the code cannot arise from a peripheral that was never reachable, so it is honoured on every platform.
+ - Update federated package constraints to `^1.1.2`.
+
 ## 1.1.1
 
  - FIX(ble): retry the whole connection sequence through transient Android `GATT_ERROR` 133 failures, including failures during service discovery and notification subscription.

--- a/packages/flutter_midi_command_android/CHANGELOG.md
+++ b/packages/flutter_midi_command_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Bump "flutter_midi_command_android" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.
+
 ## 1.1.1
 
  - Bump "flutter_midi_command_android" to `1.1.1` and update the platform interface dependency constraint to `^1.1.1`.

--- a/packages/flutter_midi_command_android/pubspec.yaml
+++ b/packages/flutter_midi_command_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_android
 description: The Android implementation of flutter_midi_command, bridging the platform MIDI APIs to send and receive MIDI messages.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_android
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_midi_command_ble/CHANGELOG.md
+++ b/packages/flutter_midi_command_ble/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - FIX: treat `deviceDisconnected` during the connection sequence as a transient link failure and retry it. universal_ble fails every in-flight GATT operation with this code when an established connection is torn down, so a link that dropped with service discovery or subscription pending reported it rather than a GATT status and was never retried — 1.1.1 covered the same failure only where Android named it as a GATT status. Unlike a GATT status it cannot arise from a peripheral that was never reachable — there has to have been a connection to lose — so it is the least ambiguous of the three signals, and it applies on every platform rather than only Android.
+
 ## 1.1.1
 
  - FIX: extend the transient `GATT_ERROR` retry to cover the whole connection sequence, not just the link. 1.0.9 retried a connect that failed outright, but the Android stack can also bring the link up and then drop it part-way through the handshake — most often when reconnecting shortly after a disconnect, before it has settled. That surfaces as a failed service discovery or notification subscription rather than a failed connect, so it was never retried and the attempt was reported as a hard failure.

--- a/packages/flutter_midi_command_ble/CHANGELOG.md
+++ b/packages/flutter_midi_command_ble/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.2
 
  - FIX: treat `deviceDisconnected` during the connection sequence as a transient link failure and retry it. universal_ble fails every in-flight GATT operation with this code when an established connection is torn down, so a link that dropped with service discovery or subscription pending reported it rather than a GATT status and was never retried — 1.1.1 covered the same failure only where Android named it as a GATT status. Unlike a GATT status it cannot arise from a peripheral that was never reachable — there has to have been a connection to lose — so it is the least ambiguous of the three signals, and it applies on every platform rather than only Android.
+ - Update the platform interface dependency constraint to `^1.1.2`.
 
 ## 1.1.1
 

--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -54,27 +54,37 @@ bool _isPairingInfoRemoved(Object error) =>
     error is UniversalBleException &&
     error.message.toLowerCase().contains('pairing information');
 
-/// True when [error] is Android's generic `GATT_ERROR` (0x85 / 133). The
-/// Android stack returns it for almost any connection that failed or was
-/// dropped during the handshake, and universal_ble has no HCI name for it.
+/// True when [error] says the link failed or went away underneath us, rather
+/// than the peripheral answering with something meaningful. Such a failure is
+/// usually transient, and a second attempt after a short settle succeeds.
 ///
-/// Two shapes reach us. A failure on the connect call itself carries no status
-/// of its own and arrives as `UniversalBleException(unknownError, "Unknown
-/// Error 133")`. A GATT operation that fails because the link went away
-/// mid-handshake is named after the operation instead — "Failed to update
-/// subscription state" — and carries the status in `details`, as a string from
-/// Android and as an int elsewhere.
+/// Three shapes reach us.
 ///
-/// Either way it is usually transient: the stack has torn the GATT client down
-/// and a second attempt, after a short settle, succeeds.
+/// `deviceDisconnected` is the least ambiguous: universal_ble fails every
+/// in-flight GATT operation with it when an established connection is torn
+/// down. It cannot arise from a peripheral that was never reachable — there
+/// has to have been a connection to lose — so it always means the link dropped
+/// mid-handshake. Platform-independent.
+///
+/// The other two are Android's generic `GATT_ERROR` (0x85 / 133), which the
+/// stack returns for almost any connection that failed or was dropped during
+/// the handshake and which universal_ble has no HCI name for. A failure on the
+/// connect call itself carries no status of its own and arrives as
+/// `UniversalBleException(unknownError, "Unknown Error 133")`. A GATT
+/// operation that fails this way is named after the operation instead —
+/// "Failed to update subscription state" — and carries the status in
+/// `details`.
 ///
 /// The `details` reading is deliberately restricted to Android. GATT status
 /// codes are an Android concept, and Apple puts the raw `NSError` code in the
 /// same field — where 133 is `0x85`, inside `CBATTError`'s application-defined
 /// range, and means something else entirely.
-bool _isTransientGattError(Object error) {
+bool _isTransientLinkFailure(Object error) {
   if (error is! UniversalBleException) {
     return false;
+  }
+  if (error.code == UniversalBleErrorCode.deviceDisconnected) {
+    return true;
   }
   if (error.message.contains('Unknown Error 133')) {
     return true;
@@ -87,7 +97,7 @@ bool _isTransientGattError(Object error) {
 }
 
 /// How long to let the Android stack settle before retrying through a
-/// [_isTransientGattError] failure.
+/// [_isTransientLinkFailure] failure.
 const _gattRetryDelay = Duration(milliseconds: 500);
 
 /// Cap on the opportunistic MTU exchange. Well under the 10 s global
@@ -691,12 +701,11 @@ class _BleMidiDevice extends MidiDevice {
               cause: error,
             );
           }
-          if (attempt > 0 || !_isTransientGattError(cause)) {
+          if (attempt > 0 || !_isTransientLinkFailure(cause)) {
             rethrow;
           }
           _log(
-            '$deviceId: link dropped with GATT_ERROR during setup ($error); '
-            'retrying once',
+            '$deviceId: link dropped during setup ($error); retrying once',
           );
         }
         await Future<void>.delayed(_gattRetryDelay);

--- a/packages/flutter_midi_command_ble/pubspec.yaml
+++ b/packages/flutter_midi_command_ble/pubspec.yaml
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
   universal_ble: ^2.1.1
 
 dev_dependencies:

--- a/packages/flutter_midi_command_ble/pubspec.yaml
+++ b/packages/flutter_midi_command_ble/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_ble
 description: Shared BLE MIDI transport for flutter_midi_command based on universal_ble.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_ble
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -45,6 +45,10 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
   /// the GATT status carried in `details` as a string.
   final Map<String, int> transientGattSubscribeFailures = <String, int>{};
 
+  /// Number of remaining `discoverServices` attempts that fail because the
+  /// link was torn down with the operation in flight.
+  final Map<String, int> disconnectedDiscoverFailures = <String, int>{};
+
   /// GATT operations in the order the transport issued them.
   final List<String> gattCalls = <String>[];
 
@@ -139,6 +143,19 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
     bool withDescriptors,
   ) async {
     gattCalls.add('discover');
+    final remaining = disconnectedDiscoverFailures[deviceId] ?? 0;
+    if (remaining > 0) {
+      disconnectedDiscoverFailures[deviceId] = remaining - 1;
+      updateConnection(deviceId, false);
+      _connectionByDevice[deviceId] = BleConnectionState.disconnected;
+      // universal_ble fails every in-flight GATT operation this way when the
+      // link is torn down underneath it.
+      throw UniversalBleException(
+        code: UniversalBleErrorCode.deviceDisconnected,
+        message: 'Device Disconnected',
+        details: 'DEVICE_DISCONNECTED',
+      );
+    }
     return servicesByDevice[deviceId] ?? <BleService>[];
   }
 
@@ -462,6 +479,33 @@ void main() {
     ]);
     expect(device.connected, isTrue);
     expect((await transport.devices).single.id, 'ble-sub-133');
+  });
+
+  test('connectToDevice retries a link torn down during discovery', () async {
+    // The observed Android failure: the link comes up, discovery is issued, and
+    // the link drops with it in flight. universal_ble reports it as
+    // deviceDisconnected rather than a GATT status, so it is only classified as
+    // transient by the error code. Not platform-specific — the code means the
+    // same thing everywhere, so pin the platform to iOS to prove it.
+    debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+    addTearDown(() => debugDefaultTargetPlatformOverride = null);
+    fakePlatform.servicesByDevice['ble-disc-drop'] = midiServices();
+    fakePlatform.disconnectedDiscoverFailures['ble-disc-drop'] = 1;
+    fakePlatform.emitScanDevice(
+      BleDevice(
+        deviceId: 'ble-disc-drop',
+        name: 'Dropped Discovery',
+        services: <String>[],
+      ),
+    );
+    final device = (await transport.devices).single;
+
+    await transport.connectToDevice(device);
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+
+    expect(fakePlatform.connectCalls, <String>['ble-disc-drop', 'ble-disc-drop']);
+    expect(device.connected, isTrue);
+    expect((await transport.devices).single.id, 'ble-disc-drop');
   });
 
   test('removed pairing is typed even when a later stage reports it', () async {

--- a/packages/flutter_midi_command_darwin/CHANGELOG.md
+++ b/packages/flutter_midi_command_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Bump "flutter_midi_command_darwin" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.
+
 ## 1.1.1
 
  - Bump "flutter_midi_command_darwin" to `1.1.1` and update the platform interface dependency constraint to `^1.1.1`.

--- a/packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/.swiftpm/xcode/xcuserdata/morten.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/.swiftpm/xcode/xcuserdata/morten.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>flutter-midi-command-darwin.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>11</integer>
 		</dict>
 	</dict>
 </dict>

--- a/packages/flutter_midi_command_darwin/pubspec.yaml
+++ b/packages/flutter_midi_command_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_darwin
 description: Darwin (iOS/macOS) serial MIDI wrapper for flutter_midi_command.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_darwin
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_midi_command_linux/CHANGELOG.md
+++ b/packages/flutter_midi_command_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Bump "flutter_midi_command_linux" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.
+
 ## 1.1.1
 
  - Bump "flutter_midi_command_linux" to `1.1.1` and update the platform interface dependency constraint to `^1.1.1`.

--- a/packages/flutter_midi_command_linux/pubspec.yaml
+++ b/packages/flutter_midi_command_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_linux
 description: The Linux implementation of flutter_midi_command, using ALSA sequencer to send and receive MIDI messages.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_linux
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
   ffi: ^2.0.1
 
 dev_dependencies:

--- a/packages/flutter_midi_command_platform_interface/CHANGELOG.md
+++ b/packages/flutter_midi_command_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Bump "flutter_midi_command_platform_interface" to `1.1.2` for the synchronized workspace release.
+
 ## 1.1.1
 
  - Bump "flutter_midi_command_platform_interface" to `1.1.1` for the synchronized workspace release.

--- a/packages/flutter_midi_command_platform_interface/pubspec.yaml
+++ b/packages/flutter_midi_command_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_platform_interface
 description: A common platform interface for the FlutterMidiCommand plugin.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_platform_interface
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues

--- a/packages/flutter_midi_command_web/CHANGELOG.md
+++ b/packages/flutter_midi_command_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Bump "flutter_midi_command_web" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.
+
 ## 1.1.1
 
  - Bump "flutter_midi_command_web" to `1.1.1` and update the platform interface dependency constraint to `^1.1.1`.

--- a/packages/flutter_midi_command_web/pubspec.yaml
+++ b/packages/flutter_midi_command_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_web
 description: The web implementation of flutter_midi_command, using the browser Web MIDI API to send and receive MIDI messages.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_web
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -25,7 +25,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   web: ^1.1.1
-  flutter_midi_command_platform_interface: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_midi_command_windows/CHANGELOG.md
+++ b/packages/flutter_midi_command_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Bump "flutter_midi_command_windows" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.
+
 ## 1.1.1
 
  - Bump "flutter_midi_command_windows" to `1.1.1` and update the platform interface dependency constraint to `^1.1.1`.

--- a/packages/flutter_midi_command_windows/pubspec.yaml
+++ b/packages/flutter_midi_command_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_windows
 description: The Windows implementation of flutter_midi_command, using the WinMM MIDI API to send and receive MIDI messages.
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_windows
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
   ffi: ^2.1.4
   win32: ^6.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_midi_command
 description: A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices.
 
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -35,12 +35,12 @@ dependencies:
   flutter:
     sdk: flutter
   async: ^2.12.0
-  flutter_midi_command_platform_interface: ^1.1.1
-  flutter_midi_command_linux: ^1.1.1
-  flutter_midi_command_windows: ^1.1.1
-  flutter_midi_command_web: ^1.1.1
-  flutter_midi_command_android: ^1.1.1
-  flutter_midi_command_darwin: ^1.1.1
+  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_linux: ^1.1.2
+  flutter_midi_command_windows: ^1.1.2
+  flutter_midi_command_web: ^1.1.2
+  flutter_midi_command_android: ^1.1.2
+  flutter_midi_command_darwin: ^1.1.2
     
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Observed on Android: the link comes up, service discovery is issued, and the link drops with it in flight. universal_ble reports that as deviceDisconnected rather than a GATT status, so the retry shipped in 1.1.1 did not apply and the attempt failed outright — a reconnect moments later succeeded.

universal_ble raises this code from cleanUpConnection, which fails every pending GATT operation when an established connection is torn down. It therefore cannot arise from a peripheral that was never reachable: there has to have been a connection to lose. That makes it a stronger signal than GATT 133, which Android also returns for connects that never succeeded, and it means the same thing on every platform — so unlike the GATT status reading it is not gated to Android.

Renames the classifier to _isTransientLinkFailure, since it no longer describes only GATT errors. Bumps to 1.1.2.