### PR TITLE
fix: return futures from virtual device and network session APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,22 @@ Use `MidiTransportPolicy` to enable/disable transports at runtime. Transport-spe
 
 A host-native device can report `MidiDeviceType.ble` while still communicating through host MIDI APIs (for example paired CoreMIDI/Android host devices). Do not assume `type == ble` always means Dart BLE transport is used internally.
 
+### 7) Virtual device and network session APIs return futures
+
+`addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` return `Future<void>` instead of `void`. They previously discarded the platform call, so a failure such as `PlatformException(AUDIOERROR, Error -2 while create MIDI virtual source)` surfaced as an unhandled asynchronous error that no `try`/`catch` around the call could see.
+
+Await them to handle failures:
+
+```dart
+try {
+  await midi.addVirtualDevice(name: 'My App');
+} on PlatformException catch (err) {
+  // The virtual source was not created.
+}
+```
+
+Existing calls that ignore the result keep compiling. Custom `MidiCommandPlatform` implementations must widen these three overrides from `void` to `Future<void>`.
+
 For help getting started with Flutter, view our online
 [documentation](https://flutter.dev/).
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -210,7 +210,7 @@ class MyAppState extends State<MyApp> {
 
     if (enabled) {
       try {
-        _midiCommand.setNetworkSessionEnabled(true);
+        await _midiCommand.setNetworkSessionEnabled(true);
       } catch (_) {}
     }
 
@@ -224,7 +224,7 @@ class MyAppState extends State<MyApp> {
 
     if (!enabled) {
       try {
-        _midiCommand.removeVirtualDevice(name: "Flutter MIDI Command");
+        await _midiCommand.removeVirtualDevice(name: "Flutter MIDI Command");
       } catch (_) {}
     }
 
@@ -235,8 +235,20 @@ class MyAppState extends State<MyApp> {
 
     if (enabled) {
       try {
-        _midiCommand.addVirtualDevice(name: "Flutter MIDI Command");
-      } catch (_) {}
+        await _midiCommand.addVirtualDevice(name: "Flutter MIDI Command");
+      } catch (err) {
+        // Creating the virtual source can fail on the platform side; the
+        // toggle must not keep claiming a source that does not exist.
+        if (kDebugMode) {
+          print("Could not create virtual device $err");
+        }
+        if (mounted) {
+          setState(() {
+            _virtualDeviceActivated = false;
+          });
+          _applyTransportPolicy();
+        }
+      }
     }
 
     await _refreshDevices(showLoading: false);

--- a/example/test/support/fake_midi_platform.dart
+++ b/example/test/support/fake_midi_platform.dart
@@ -88,12 +88,12 @@ class FakeMidiPlatform extends MidiCommandPlatform {
       _setupStreamController.stream;
 
   @override
-  void addVirtualDevice({String? name}) {
+  Future<void> addVirtualDevice({String? name}) async {
     addedVirtualDeviceNames.add(name);
   }
 
   @override
-  void removeVirtualDevice({String? name}) {
+  Future<void> removeVirtualDevice({String? name}) async {
     removedVirtualDeviceNames.add(name);
   }
 
@@ -101,7 +101,7 @@ class FakeMidiPlatform extends MidiCommandPlatform {
   Future<bool?> get isNetworkSessionEnabled async => networkEnabled;
 
   @override
-  void setNetworkSessionEnabled(bool enabled) {
+  Future<void> setNetworkSessionEnabled(bool enabled) async {
     networkEnabled = enabled;
     networkEnabledChanges.add(enabled);
   }

--- a/lib/flutter_midi_command.dart
+++ b/lib/flutter_midi_command.dart
@@ -621,16 +621,22 @@ class MidiCommand {
   /// The virtual MIDI source appears as a virtual port in other apps.
   /// Other apps can receive MIDI from this source.
   /// Currently only supported on iOS.
-  void addVirtualDevice({String? name}) {
+  ///
+  /// Completes once the platform has created the source, and completes with
+  /// the platform error when it could not.
+  Future<void> addVirtualDevice({String? name}) async {
     _requireTransport(MidiTransport.virtual, 'addVirtualDevice');
-    _platform.addVirtualDevice(name: name);
+    await _platform.addVirtualDevice(name: name);
   }
 
   /// Removes a previously created virtual MIDI source.
   /// Currently only supported on iOS.
-  void removeVirtualDevice({String? name}) {
+  ///
+  /// Completes once the platform has removed the source, and completes with
+  /// the platform error when it could not.
+  Future<void> removeVirtualDevice({String? name}) async {
     _requireTransport(MidiTransport.virtual, 'removeVirtualDevice');
-    _platform.removeVirtualDevice(name: name);
+    await _platform.removeVirtualDevice(name: name);
   }
 
   /// Returns the current state of the network session
@@ -644,9 +650,12 @@ class MidiCommand {
   /// Sets the enabled state of the network session
   ///
   /// This is functional on iOS only
-  void setNetworkSessionEnabled(bool enabled) {
+  ///
+  /// Completes once the platform has applied the state, and completes with the
+  /// platform error when it could not.
+  Future<void> setNetworkSessionEnabled(bool enabled) async {
     _requireTransport(MidiTransport.network, 'setNetworkSessionEnabled');
-    _platform.setNetworkSessionEnabled(enabled);
+    await _platform.setNetworkSessionEnabled(enabled);
   }
 
   Future<void> _awaitConnectedOrFailed(MidiDevice device) {

--- a/packages/flutter_midi_command_linux/lib/flutter_midi_command_linux.dart
+++ b/packages/flutter_midi_command_linux/lib/flutter_midi_command_linux.dart
@@ -227,16 +227,16 @@ class FlutterMidiCommandLinux extends MidiCommandPlatform {
   Stream<MidiSetupChange>? get onMidiSetupChanged => _setupStream;
 
   @override
-  void addVirtualDevice({String? name}) {}
+  Future<void> addVirtualDevice({String? name}) async {}
 
   @override
-  void removeVirtualDevice({String? name}) {}
+  Future<void> removeVirtualDevice({String? name}) async {}
 
   @override
   Future<bool?> get isNetworkSessionEnabled async => null;
 
   @override
-  void setNetworkSessionEnabled(bool enabled) {}
+  Future<void> setNetworkSessionEnabled(bool enabled) async {}
 
   void _addSetupEvent(MidiSetupChange event) {
     if (!_setupStreamController.isClosed) {

--- a/packages/flutter_midi_command_linux/test/flutter_midi_command_linux_test.dart
+++ b/packages/flutter_midi_command_linux/test/flutter_midi_command_linux_test.dart
@@ -16,16 +16,13 @@ void main() {
 
     expect(plugin.onMidiDataReceived, isNotNull);
     expect(plugin.onMidiSetupChanged, isNotNull);
-    expect(
-      () => plugin.addVirtualDevice(name: 'Test Virtual'),
-      returnsNormally,
-    );
-    expect(
-      () => plugin.removeVirtualDevice(name: 'Test Virtual'),
-      returnsNormally,
+    await expectLater(plugin.addVirtualDevice(name: 'Test Virtual'), completes);
+    await expectLater(
+      plugin.removeVirtualDevice(name: 'Test Virtual'),
+      completes,
     );
     expect(await plugin.isNetworkSessionEnabled, isNull);
-    expect(() => plugin.setNetworkSessionEnabled(true), returnsNormally);
+    await expectLater(plugin.setNetworkSessionEnabled(true), completes);
   });
 
   test('devices refreshes discovery on each call', () async {

--- a/packages/flutter_midi_command_platform_interface/lib/flutter_midi_command_platform_interface.dart
+++ b/packages/flutter_midi_command_platform_interface/lib/flutter_midi_command_platform_interface.dart
@@ -80,12 +80,18 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   }
 
   /// Creates a virtual MIDI source.
-  void addVirtualDevice({String? name}) {
+  ///
+  /// The returned future completes with the platform error when creation
+  /// fails, so implementations must not discard the underlying call.
+  Future<void> addVirtualDevice({String? name}) {
     throw UnimplementedError('addVirtualDevice() has not been implemented.');
   }
 
   /// Removes a previously created virtual MIDI source.
-  void removeVirtualDevice({String? name}) {
+  ///
+  /// The returned future completes with the platform error when removal
+  /// fails, so implementations must not discard the underlying call.
+  Future<void> removeVirtualDevice({String? name}) {
     throw UnimplementedError('removeVirtualDevice() has not been implemented.');
   }
 
@@ -97,7 +103,11 @@ abstract class MidiCommandPlatform extends PlatformInterface {
   }
 
   /// Sets the enabled state of the network session (iOS only)
-  void setNetworkSessionEnabled(bool enabled) {
+  ///
+  /// The returned future completes with the platform error when the state
+  /// could not be applied, so implementations must not discard the underlying
+  /// call.
+  Future<void> setNetworkSessionEnabled(bool enabled) {
     throw UnimplementedError(
       'setNetworkSessionEnabled has not been implemented.',
     );

--- a/packages/flutter_midi_command_platform_interface/lib/method_channel_midi_command.dart
+++ b/packages/flutter_midi_command_platform_interface/lib/method_channel_midi_command.dart
@@ -303,14 +303,14 @@ class MethodChannelMidiCommand extends MidiCommandPlatform
   /// The virtual MIDI source appears as a virtual port in other apps.
   /// Currently only supported on iOS.
   @override
-  void addVirtualDevice({String? name}) {
-    unawaited(_hostApi.addVirtualDevice(name));
+  Future<void> addVirtualDevice({String? name}) {
+    return _hostApi.addVirtualDevice(name);
   }
 
-  /// Removes a previously addd virtual MIDI source.
+  /// Removes a previously added virtual MIDI source.
   @override
-  void removeVirtualDevice({String? name}) {
-    unawaited(_hostApi.removeVirtualDevice(name));
+  Future<void> removeVirtualDevice({String? name}) {
+    return _hostApi.removeVirtualDevice(name);
   }
 
   /// Returns the current state of the network session
@@ -325,8 +325,8 @@ class MethodChannelMidiCommand extends MidiCommandPlatform
   ///
   /// This is functional on iOS only
   @override
-  void setNetworkSessionEnabled(bool enabled) {
-    unawaited(_hostApi.setNetworkSessionEnabled(enabled));
+  Future<void> setNetworkSessionEnabled(bool enabled) {
+    return _hostApi.setNetworkSessionEnabled(enabled);
   }
 }
 

--- a/packages/flutter_midi_command_platform_interface/test/method_channel_midi_command_test.dart
+++ b/packages/flutter_midi_command_platform_interface/test/method_channel_midi_command_test.dart
@@ -1,5 +1,4 @@
-import 'dart:typed_data';
-
+import 'package:flutter/services.dart';
 import 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart';
 import 'package:flutter_midi_command_platform_interface/method_channel_midi_command.dart';
 import 'package:flutter_midi_command_platform_interface/src/pigeon/midi_api.g.dart'
@@ -18,6 +17,7 @@ class _FakeHostApi extends pigeon.MidiHostApi {
   String? lastVirtualName;
   bool? networkEnabled = false;
   bool? setNetworkEnabledArg;
+  Object? virtualDeviceError;
 
   @override
   Future<List<pigeon.MidiHostDevice>> listDevices() async => listedDevices;
@@ -50,12 +50,18 @@ class _FakeHostApi extends pigeon.MidiHostApi {
   Future<void> addVirtualDevice(String? name) async {
     addVirtualCalls += 1;
     lastVirtualName = name;
+    if (virtualDeviceError != null) {
+      throw virtualDeviceError!;
+    }
   }
 
   @override
   Future<void> removeVirtualDevice(String? name) async {
     removeVirtualCalls += 1;
     lastVirtualName = name;
+    if (virtualDeviceError != null) {
+      throw virtualDeviceError!;
+    }
   }
 
   @override
@@ -319,6 +325,25 @@ void main() {
     expect(packets.first.device.type, MidiDeviceType.serial);
   });
 
+  test('virtual device failures reach the caller', () async {
+    final host =
+        _FakeHostApi()
+          ..virtualDeviceError = PlatformException(
+            code: 'AUDIOERROR',
+            message: 'Error -2 while create MIDI virtual source',
+          );
+    final platform = MethodChannelMidiCommand(hostApi: host);
+
+    await expectLater(
+      platform.addVirtualDevice(name: 'Virtual'),
+      throwsA(isA<PlatformException>()),
+    );
+    await expectLater(
+      platform.removeVirtualDevice(name: 'Virtual'),
+      throwsA(isA<PlatformException>()),
+    );
+  });
+
   test('virtual/network/teardown methods delegate to host api', () async {
     final host = _FakeHostApi()..networkEnabled = true;
     final platform = MethodChannelMidiCommand(hostApi: host);
@@ -330,10 +355,10 @@ void main() {
     );
 
     await platform.connectToDevice(connected);
-    platform.addVirtualDevice(name: 'Virtual');
-    platform.removeVirtualDevice(name: 'Virtual');
+    await platform.addVirtualDevice(name: 'Virtual');
+    await platform.removeVirtualDevice(name: 'Virtual');
     final networkEnabled = await platform.isNetworkSessionEnabled;
-    platform.setNetworkSessionEnabled(false);
+    await platform.setNetworkSessionEnabled(false);
     platform.teardown();
     await Future<void>.delayed(Duration.zero);
 

--- a/packages/flutter_midi_command_web/lib/flutter_midi_command_web.dart
+++ b/packages/flutter_midi_command_web/lib/flutter_midi_command_web.dart
@@ -439,12 +439,12 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
   }
 
   @override
-  void addVirtualDevice({String? name}) {
+  Future<void> addVirtualDevice({String? name}) async {
     throw _unsupported('virtual MIDI devices are not supported on web.');
   }
 
   @override
-  void removeVirtualDevice({String? name}) {
+  Future<void> removeVirtualDevice({String? name}) async {
     throw _unsupported('virtual MIDI devices are not supported on web.');
   }
 
@@ -452,7 +452,7 @@ class FlutterMidiCommandWeb extends MidiCommandPlatform {
   Future<bool?> get isNetworkSessionEnabled async => false;
 
   @override
-  void setNetworkSessionEnabled(bool enabled) {
+  Future<void> setNetworkSessionEnabled(bool enabled) async {
     // No-op on web.
   }
 

--- a/packages/flutter_midi_command_windows/lib/flutter_midi_command_windows.dart
+++ b/packages/flutter_midi_command_windows/lib/flutter_midi_command_windows.dart
@@ -201,16 +201,16 @@ class FlutterMidiCommandWindows extends MidiCommandPlatform {
   Stream<MidiSetupChange>? get onMidiSetupChanged => _setupStream;
 
   @override
-  void addVirtualDevice({String? name}) {}
+  Future<void> addVirtualDevice({String? name}) async {}
 
   @override
-  void removeVirtualDevice({String? name}) {}
+  Future<void> removeVirtualDevice({String? name}) async {}
 
   @override
   Future<bool?> get isNetworkSessionEnabled async => false;
 
   @override
-  void setNetworkSessionEnabled(bool enabled) {}
+  Future<void> setNetworkSessionEnabled(bool enabled) async {}
 
   WindowsMidiDevice? findMidiDeviceForSource(int src) {
     for (final wmd in _connectedDevices.values) {

--- a/test/flutter_midi_command_test.dart
+++ b/test/flutter_midi_command_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_midi_command/flutter_midi_command.dart';
 import 'package:flutter_midi_command/flutter_midi_command_messages.dart';
 import 'package:flutter_midi_command_platform_interface/flutter_midi_command_platform_interface.dart';
@@ -50,6 +51,26 @@ class _FakePlatform extends MidiCommandPlatform {
 
   @override
   Stream<MidiSetupChange>? get onMidiSetupChanged => _setup.stream;
+
+  Object? virtualDeviceError;
+  final addedVirtualDevices = <String?>[];
+  final removedVirtualDevices = <String?>[];
+
+  @override
+  Future<void> addVirtualDevice({String? name}) async {
+    addedVirtualDevices.add(name);
+    if (virtualDeviceError != null) {
+      throw virtualDeviceError!;
+    }
+  }
+
+  @override
+  Future<void> removeVirtualDevice({String? name}) async {
+    removedVirtualDevices.add(name);
+    if (virtualDeviceError != null) {
+      throw virtualDeviceError!;
+    }
+  }
 
   void emitPacket(MidiPacket packet) {
     _rx.add(packet);
@@ -260,6 +281,38 @@ void main() {
 
   tearDown(() {
     debugDefaultTargetPlatformOverride = null;
+  });
+
+  test('addVirtualDevice reports platform failures to the caller', () async {
+    final platform =
+        _FakePlatform()
+          ..virtualDeviceError = PlatformException(
+            code: 'AUDIOERROR',
+            message: 'Error -2 while create MIDI virtual source',
+          );
+    MidiCommand.setPlatformOverride(platform);
+    final midi = MidiCommand();
+
+    await expectLater(
+      midi.addVirtualDevice(name: 'Virtual'),
+      throwsA(isA<PlatformException>()),
+    );
+    await expectLater(
+      midi.removeVirtualDevice(name: 'Virtual'),
+      throwsA(isA<PlatformException>()),
+    );
+    expect(platform.addedVirtualDevices, <String?>['Virtual']);
+    expect(platform.removedVirtualDevices, <String?>['Virtual']);
+  });
+
+  test('addVirtualDevice completes when the platform succeeds', () async {
+    final platform = _FakePlatform();
+    MidiCommand.setPlatformOverride(platform);
+    final midi = MidiCommand();
+
+    await midi.addVirtualDevice(name: 'Virtual');
+
+    expect(platform.addedVirtualDevices, <String?>['Virtual']);
   });
 
   test('BLE APIs require BLE transport implementation', () async {


### PR DESCRIPTION
Fixes #173.

## Problem

`MethodChannelMidiCommand` dropped the pigeon call with `unawaited`, so a platform failure escaped as an unhandled asynchronous error:

```
PlatformException(AUDIOERROR, Error -2 while create MIDI virtual source, null, null)
  at MidiHostApi.addVirtualDevice (midi_api.g.dart:331)
```

Wrapping the call in `try`/`catch` could not help, because the future was discarded inside the platform implementation rather than returned to the caller.

## Fix

`addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` now return `Future<void>` end to end — `MidiCommand` → `MidiCommandPlatform` → `MethodChannelMidiCommand` → host API:

```dart
try {
  await midi.addVirtualDevice(name: 'My App');
} on PlatformException catch (err) {
  // The virtual source was not created.
}
```

`setNetworkSessionEnabled` had the identical `unawaited` defect one line below the two named in the issue; including it here keeps this to a single breaking-signature change rather than two.

Updated in the same shape: the platform-interface base class, and the web, windows and linux implementations. Web now throws asynchronously via `async` so its "unsupported" error arrives through the future rather than synchronously.

## Compatibility

- Existing calls that ignore the result keep compiling (`midi.addVirtualDevice(name: 'x');` is still a valid statement).
- Breaking for custom `MidiCommandPlatform` implementations: the three overrides must widen from `void` to `Future<void>`. Documented as migration item 7 in the README.

## Verification

- New test in `test/flutter_midi_command_test.dart` asserting a platform error reaches a `MidiCommand` caller, plus a success-path test.
- New test in the platform interface asserting `PlatformException` propagates out of `MethodChannelMidiCommand`.
- The example app now awaits `addVirtualDevice` and reverts its virtual transport toggle when creation fails — previously it silently kept the toggle on.
- `flutter analyze` clean; root, platform-interface, linux, windows, web (chrome) and example suites pass.