### PR TITLE
fix(darwin): create MIDINetworkSession lazily, not at plugin init

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Supports
   - Android: plugin package minimum is `minSdkVersion(21)` (`packages/flutter_midi_command_android/android/build.gradle.kts`), while the example app currently uses `minSdkVersion(24)` (`example/android/app/build.gradle.kts`).
 - Android BLE permissions are merged automatically when `flutter_midi_command_ble` is installed.
 - Apple usage descriptions/capabilities and packaged Windows/Linux permissions remain application-owned. See the [BLE platform setup guide](https://pub.dev/packages/flutter_midi_command_ble#platform-setup).
-- If using network MIDI on iOS, add `NSLocalNetworkUsageDescription`.
+- If using network MIDI on iOS, add `NSLocalNetworkUsageDescription`. The system local-network prompt appears the first time you call `setNetworkSessionEnabled(true)`, not at app launch.
 - On Linux, make sure ALSA is installed.
 - On Web, use HTTPS and a browser with Web MIDI enabled (for example Chrome/Edge).
 

--- a/packages/flutter_midi_command_darwin/CHANGELOG.md
+++ b/packages/flutter_midi_command_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+ - FIX(ios): do not touch `MIDINetworkSession.default()` in `setup()`. Creating the session at plugin init made iOS 14+ show the system "Allow [app] to find devices on local networks" permission prompt at app startup, even though network MIDI is disabled by default. The session is now created lazily in `setNetworkSessionEnabled(true)`, the existing explicit opt-in for network (RTP) MIDI.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_darwin" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_darwin/CHANGELOG.md
+++ b/packages/flutter_midi_command_darwin/CHANGELOG.md
@@ -1,7 +1,3 @@
-## Unreleased
-
- - FIX(ios): do not touch `MIDINetworkSession.default()` in `setup()`. Creating the session at plugin init made iOS 14+ show the system "Allow [app] to find devices on local networks" permission prompt at app startup, even though network MIDI is disabled by default. The session is now created lazily in `setNetworkSessionEnabled(true)`, the existing explicit opt-in for network (RTP) MIDI.
-
 ## 1.1.2
 
  - Bump "flutter_midi_command_darwin" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/Sources/flutter_midi_command_darwin/SwiftFlutterMidiCommandPlugin.swift
+++ b/packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/Sources/flutter_midi_command_darwin/SwiftFlutterMidiCommandPlugin.swift
@@ -115,15 +115,6 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, FlutterPlugin, MidiHostApi
             self.handleMIDINotification(notification)
         }
         knownDeviceSnapshots = currentDeviceSnapshots()
-
-#if os(iOS)
-        // Do not create the MIDI network session here. Touching
-        // MIDINetworkSession.default() makes iOS 14+ show the system
-        // "Allow [app] to find devices on local networks" permission prompt
-        // at app startup, even though network MIDI is disabled by default.
-        // The session is created lazily in setNetworkSessionEnabled(true),
-        // which is the explicit opt-in for network (RTP) MIDI.
-#endif
     }
 
     func updateSetupState(data: MidiSetupChange) {
@@ -219,6 +210,9 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, FlutterPlugin, MidiHostApi
 
     func setNetworkSessionEnabled(enabled: Bool) throws {
 #if os(iOS)
+        // Created lazily, never at plugin init: touching MIDINetworkSession.default()
+        // makes iOS 14+ show the system "Allow [app] to find devices on local
+        // networks" prompt, and network MIDI is opt-in.
         if enabled && session == nil {
             session = MIDINetworkSession.default()
             session?.connectionPolicy = MIDINetworkConnectionPolicy.anyone

--- a/packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/Sources/flutter_midi_command_darwin/SwiftFlutterMidiCommandPlugin.swift
+++ b/packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/Sources/flutter_midi_command_darwin/SwiftFlutterMidiCommandPlugin.swift
@@ -117,8 +117,12 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, FlutterPlugin, MidiHostApi
         knownDeviceSnapshots = currentDeviceSnapshots()
 
 #if os(iOS)
-        session = MIDINetworkSession.default()
-        session?.connectionPolicy = MIDINetworkConnectionPolicy.anyone
+        // Do not create the MIDI network session here. Touching
+        // MIDINetworkSession.default() makes iOS 14+ show the system
+        // "Allow [app] to find devices on local networks" permission prompt
+        // at app startup, even though network MIDI is disabled by default.
+        // The session is created lazily in setNetworkSessionEnabled(true),
+        // which is the explicit opt-in for network (RTP) MIDI.
 #endif
     }
 
@@ -215,6 +219,10 @@ public class SwiftFlutterMidiCommandPlugin: NSObject, FlutterPlugin, MidiHostApi
 
     func setNetworkSessionEnabled(enabled: Bool) throws {
 #if os(iOS)
+        if enabled && session == nil {
+            session = MIDINetworkSession.default()
+            session?.connectionPolicy = MIDINetworkConnectionPolicy.anyone
+        }
         session?.isEnabled = enabled
 #endif
     }


### PR DESCRIPTION
## Problem

On iOS 14+, touching `MIDINetworkSession.default()` in `setup()` makes the system show the **"Allow [app] to find devices on local networks"** permission prompt at app startup — even though the network session is *disabled* by default (`isEnabled == false`) and the app may only use Bluetooth/USB/virtual MIDI.

Users see a confusing network-permission dialog before the first screen, with no way for the app to avoid it (the standard `NSLocalNetworkUsageDescription` string does not remove the prompt, it only changes the body text).

## Fix

Stop creating the session at plugin init. Create it lazily inside `setNetworkSessionEnabled(true)` — which is already the documented, explicit opt-in for network (RTP) MIDI (see the iOS-specific API added in 0.4.15).

```swift
func setNetworkSessionEnabled(enabled: Bool) throws {
#if os(iOS)
    if enabled && session == nil {
        session = MIDINetworkSession.default()
        session?.connectionPolicy = MIDINetworkConnectionPolicy.anyone
    }
    session?.isEnabled = enabled
#endif
}
```

## Impact

- **Bluetooth / USB / virtual MIDI: unaffected** — they go through CoreMIDI without a network session.
- **Network MIDI via `setNetworkSessionEnabled(true)`: unchanged** — the session is created at the same call, identical behavior afterwards.
- `isNetworkSessionEnabled()` still reports `false` before any session exists, matching the disabled-by-default semantics.

## Testing

Verified on the iOS simulator with an app using this plugin:
- the system Local Network prompt no longer appears at launch;
- USB/virtual device enumeration is unchanged;
- `setNetworkSessionEnabled(true)` still creates and enables the network session.