### PR TITLE
ci(darwin): compile the plugin and run its Swift tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ build/
 local.properties
 .idea/
 *.iml
-packages/flutter_midi_command_darwin/ios/.build/
+packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/.build/
+packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin/.build-ios/
 /example/.vscode
 /.vscode
 /example/ios/Flutter/ephemeral

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,7 +98,7 @@ melos:
     test:native:android:
       run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest
     test:native:darwin:
-      run: swift package --package-path packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin describe
+      run: bash tool/darwin_native_checks.sh
     test:native:linux:
       run: dart run melos exec --scope=flutter_midi_command_linux -- "flutter test"
     test:native:windows:

--- a/tool/darwin_native_checks.sh
+++ b/tool/darwin_native_checks.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Compiles the darwin plugin sources and runs its Swift unit tests.
+#
+# `swift package describe` only reads Package.swift, so a Swift syntax or type
+# error in the plugin used to pass this job and surface much later in the
+# example app build. The sources import Flutter/FlutterMacOS, which plain
+# SwiftPM cannot resolve, so point the compiler at the engine frameworks that
+# ship with the Flutter SDK.
+set -euo pipefail
+
+PACKAGE_PATH="packages/flutter_midi_command_darwin/darwin/flutter_midi_command_darwin"
+IOS_DEPLOYMENT_TARGET="13.1"
+
+if [[ -z "${FLUTTER_ROOT:-}" ]]; then
+  FLUTTER_BIN="$(command -v flutter || true)"
+  if [[ -z "${FLUTTER_BIN}" ]]; then
+    echo "flutter not found on PATH. Set FLUTTER_ROOT to the Flutter SDK." >&2
+    exit 1
+  fi
+  FLUTTER_ROOT="$(cd "$(dirname "$(dirname "$(readlink -f "${FLUTTER_BIN}" 2>/dev/null || echo "${FLUTTER_BIN}")")")" && pwd)"
+fi
+
+# The engine frameworks are downloaded on demand, so a clean checkout may not
+# have them yet.
+flutter precache --ios --macos >/dev/null
+
+ENGINE_DIR="${FLUTTER_ROOT}/bin/cache/artifacts/engine"
+
+find_slice() {
+  # $1: xcframework name, $2: slice prefix. The artifacts directory is named
+  # for the host toolchain, not the runner architecture, so search for it.
+  local xcframework slice
+  xcframework="$(find "${ENGINE_DIR}" -maxdepth 2 -type d -name "$1" | head -1)"
+  if [[ -z "${xcframework}" ]]; then
+    echo "Could not find $1 under ${ENGINE_DIR}." >&2
+    exit 1
+  fi
+  slice="$(find "${xcframework}" -maxdepth 1 -type d -name "$2" | head -1)"
+  if [[ -z "${slice}" ]]; then
+    echo "Could not find a $2 slice in ${xcframework}." >&2
+    exit 1
+  fi
+  echo "${slice}"
+}
+
+MACOS_FRAMEWORKS="$(find_slice FlutterMacOS.xcframework 'macos-*')"
+# The device slice, so the build covers the same configuration as a release
+# app. The simulator slice would compile the same `#if os(iOS)` sources.
+IOS_FRAMEWORKS="$(find_slice Flutter.xcframework 'ios-arm64')"
+IOS_SDK="$(xcrun --sdk iphoneos --show-sdk-path)"
+
+echo "==> Package manifest"
+swift package --package-path "${PACKAGE_PATH}" describe >/dev/null
+
+echo "==> Compiling for macOS"
+swift build \
+  --package-path "${PACKAGE_PATH}" \
+  -Xswiftc -F -Xswiftc "${MACOS_FRAMEWORKS}"
+
+# Built separately because the plugin's network session, BLE handoff and
+# lifecycle code lives behind `#if os(iOS)` and is invisible to the macOS build.
+echo "==> Compiling for iOS"
+swift build \
+  --package-path "${PACKAGE_PATH}" \
+  --scratch-path "${PACKAGE_PATH}/.build-ios" \
+  --triple "arm64-apple-ios${IOS_DEPLOYMENT_TARGET}" \
+  -Xswiftc -sdk -Xswiftc "${IOS_SDK}" \
+  -Xswiftc -F -Xswiftc "${IOS_FRAMEWORKS}" \
+  -Xcc -isysroot -Xcc "${IOS_SDK}" \
+  -Xcc -F -Xcc "${IOS_FRAMEWORKS}"
+
+echo "==> Swift unit tests"
+swift build \
+  --build-tests \
+  --package-path "${PACKAGE_PATH}" \
+  -Xswiftc -F -Xswiftc "${MACOS_FRAMEWORKS}" \
+  -Xlinker -F -Xlinker "${MACOS_FRAMEWORKS}" \
+  -Xlinker -rpath -Xlinker "${MACOS_FRAMEWORKS}"
+
+TEST_BUNDLE="$(find "${PACKAGE_PATH}/.build" -maxdepth 4 -name '*PackageTests.xctest' | head -1)"
+if [[ -z "${TEST_BUNDLE}" ]]; then
+  echo "Could not find the built test bundle." >&2
+  exit 1
+fi
+
+# `swift test` cannot launch the bundle without the engine framework on the
+# dynamic loader path, so run it directly. xctest reports on stderr, which melos
+# labels as an error even on a passing run; fold it into stdout to keep CI logs
+# readable.
+DYLD_FRAMEWORK_PATH="${MACOS_FRAMEWORKS}" xcrun xctest "${TEST_BUNDLE}" 2>&1


### PR DESCRIPTION
## Problem

`melos run test:native:darwin` — the job labelled "Darwin native tests" — ran only:

```
swift package --package-path .../flutter_midi_command_darwin describe
```

`describe` reads `Package.swift` and never touches the sources. Two consequences:

1. **A Swift syntax or type error passes this job.** Real compile coverage exists only in `example_apple`, which `needs: [dart_checks, native_darwin_checks]` — so a broken plugin clears the "native darwin" gate and fails several minutes later as an example *app* build error. This came up while reviewing #175, where a stray character in `SwiftFlutterMidiCommandPlugin.swift` would have taken that path.
2. **The checked-in Swift unit tests never run.** `Tests/flutter_midi_command_darwinTests/` has `MidiPacketParserTests` and `PacketListHandlingTests` — five tests covering the packet parser and the coalesced `MIDIPacketList` handling fixed in 1.1.0. No CI job executes them.

## Fix

`tool/darwin_native_checks.sh`, wired into the existing `test:native:darwin` script (no workflow changes needed):

1. `swift package describe` — manifest sanity, as before.
2. **Compile for macOS** against `FlutterMacOS.xcframework` from the Flutter SDK.
3. **Compile for iOS** (device slice + iphoneos SDK) as a separate build. This matters: the plugin's network session, BLE handoff and lifecycle code lives behind `#if os(iOS)` and is invisible to a macOS-only build.
4. **Build and run the XCTest bundle**, so those five tests execute.

The sources `import Flutter`/`FlutterMacOS`, which plain SwiftPM cannot resolve — hence the framework search paths. `flutter precache --ios --macos` runs first so a clean runner has the engine artifacts, and the framework slices are located by search rather than hardcoded path, since the artifacts directory is named for the host toolchain rather than the runner architecture.

`swift test` cannot launch the bundle (the engine framework isn't on the loader path), so the script builds with `--build-tests` and invokes `xcrun xctest` with `DYLD_FRAMEWORK_PATH`. Its stderr is folded into stdout because melos labels stderr as `ERROR:` even on a passing run.

## Verification

Run locally on macOS: **~70s cold, ~7s warm** — cheap enough for the fast gate.

Verified it fails for the right reasons, not just passes:

- reintroducing the stray-character typo → exits 1 with `error: consecutive statements on a line must be separated by ';'` at the `==> Compiling for macOS` step;
- adding a deliberately failing XCTest → exits 1 with the test failure.

Also adds the SPM build directories to `.gitignore` (the existing entry pointed at `packages/flutter_midi_command_darwin/ios/.build/`, a path that no longer exists after the federation).

## Note

The iOS build surfaces a pre-existing warning — a non-exhaustive `switch` over `notification.messageID` in `handleMIDINotification` missing `.msgInternalStart`. Left alone here; worth a follow-up.