### PR TITLE
ci: check formatting, publishability and the example's tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,12 @@ on:
     branches:
       - main
       - master
-      - codex/restructure-repo-into-mono-repo-with-melon
+
+# A new push supersedes the run it interrupted; the macOS and emulator jobs are
+# too expensive to leave racing against themselves.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   FLUTTER_VERSION: '3.44.2'
@@ -47,10 +52,12 @@ jobs:
           dart pub global activate melos ${{ env.MELOS_VERSION }}
           echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
       - run: melos bootstrap
+      - run: melos run format:check
       - run: melos run analyze
       - run: melos run analyze:example
       - run: melos run test
       - run: melos run test:web:chrome
+      - run: melos run publish:dry-run
 
   native_android_checks:
     runs-on: ubuntu-latest
@@ -85,23 +92,6 @@ jobs:
       - run: melos bootstrap
       - name: Darwin native tests
         run: melos run test:native:darwin
-
-  native_linux_checks:
-    runs-on: ubuntu-latest
-    needs: pigeon_contracts
-    steps:
-      - uses: actions/checkout@v6
-      - uses: subosito/flutter-action@v2
-        with:
-          flutter-version: ${{ env.FLUTTER_VERSION }}
-      - name: Install Melos
-        shell: bash
-        run: |
-          dart pub global activate melos ${{ env.MELOS_VERSION }}
-          echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
-      - run: melos bootstrap
-      - name: Linux backend tests
-        run: melos run test:native:linux
 
   native_windows_checks:
     runs-on: windows-latest
@@ -160,7 +150,9 @@ jobs:
 
   example_linux:
     runs-on: ubuntu-latest
-    needs: [dart_checks, native_linux_checks]
+    # The linux backend is pure Dart, so `melos run test` in dart_checks already
+    # covers it; the build below is what exercises it on a Linux host.
+    needs: dart_checks
     steps:
       - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2

--- a/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
+++ b/packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart
@@ -704,9 +704,7 @@ class _BleMidiDevice extends MidiDevice {
           if (attempt > 0 || !_isTransientLinkFailure(cause)) {
             rethrow;
           }
-          _log(
-            '$deviceId: link dropped during setup ($error); retrying once',
-          );
+          _log('$deviceId: link dropped during setup ($error); retrying once');
         }
         await Future<void>.delayed(_gattRetryDelay);
       }
@@ -909,7 +907,9 @@ class _BleMidiDevice extends MidiDevice {
   /// ~30-50 ms default), which is the floor on MIDI latency.
   ///
   /// Best-effort: only Android implements it, and a peripheral can decline.
-  Future<void> _requestConnectionPriority(BleConnectionPriority priority) async {
+  Future<void> _requestConnectionPriority(
+    BleConnectionPriority priority,
+  ) async {
     if (!requestHighPerformanceConnection) {
       return;
     }

--- a/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
+++ b/packages/flutter_midi_command_ble/test/ble_midi_parse_test.dart
@@ -201,46 +201,49 @@ void main() {
     }
   });
 
-  test('BLE MIDI SysEx survives a chunk/parse round-trip at any size', () async {
-    BleCapabilities.hasSystemPairingApi = true;
-    final fake = _FakePlatform();
-    UniversalBle.setInstance(fake);
-    final transport = UniversalBleMidiTransport();
+  test(
+    'BLE MIDI SysEx survives a chunk/parse round-trip at any size',
+    () async {
+      BleCapabilities.hasSystemPairingApi = true;
+      final fake = _FakePlatform();
+      UniversalBle.setInstance(fake);
+      final transport = UniversalBleMidiTransport();
 
-    fake.servicesByDevice['dev'] = midiServices();
-    fake.emitScan('dev', 'GEWA');
-    final device = (await transport.devices).single;
-    await transport.connectToDevice(device);
-    await Future<void>.delayed(const Duration(milliseconds: 5));
+      fake.servicesByDevice['dev'] = midiServices();
+      fake.emitScan('dev', 'GEWA');
+      final device = (await transport.devices).single;
+      await transport.connectToDevice(device);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
 
-    final received = <List<int>>[];
-    final sub = transport.onMidiDataReceived.listen(
-      (p) => received.add(p.data.toList()),
-    );
+      final received = <List<int>>[];
+      final sub = transport.onMidiDataReceived.listen(
+        (p) => received.add(p.data.toList()),
+      );
 
-    // Sweep every body length across the packet boundaries of several write
-    // sizes, feeding the chunker's own output back through the parser.
-    final expected = <List<int>>[];
-    for (final writeSize in <int>[20, 23, 100, 244]) {
-      for (var bodyLength = 0; bodyLength <= 200; bodyLength++) {
-        final sysEx = <int>[
-          0xF0,
-          ...List<int>.generate(bodyLength, (i) => i % 0x80),
-          0xF7,
-        ];
-        expected.add(sysEx);
-        for (final packet in buildBleMidiSysExPackets(sysEx, writeSize)) {
-          fake.emitValue('dev', packet);
+      // Sweep every body length across the packet boundaries of several write
+      // sizes, feeding the chunker's own output back through the parser.
+      final expected = <List<int>>[];
+      for (final writeSize in <int>[20, 23, 100, 244]) {
+        for (var bodyLength = 0; bodyLength <= 200; bodyLength++) {
+          final sysEx = <int>[
+            0xF0,
+            ...List<int>.generate(bodyLength, (i) => i % 0x80),
+            0xF7,
+          ];
+          expected.add(sysEx);
+          for (final packet in buildBleMidiSysExPackets(sysEx, writeSize)) {
+            fake.emitValue('dev', packet);
+          }
         }
       }
-    }
 
-    await Future<void>.delayed(const Duration(milliseconds: 50));
-    await sub.cancel();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+      await sub.cancel();
 
-    expect(received, hasLength(expected.length));
-    for (var i = 0; i < expected.length; i++) {
-      expect(received[i], expected[i], reason: 'round-trip mismatch at $i');
-    }
-  });
+      expect(received, hasLength(expected.length));
+      for (var i = 0; i < expected.length; i++) {
+        expect(received[i], expected[i], reason: 'round-trip mismatch at $i');
+      }
+    },
+  );
 }

--- a/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
+++ b/packages/flutter_midi_command_ble/test/flutter_midi_command_ble_test.dart
@@ -28,7 +28,8 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
 
   /// Payloads passed to `writeValue`, in order.
   final List<List<int>> writtenPackets = <List<int>>[];
-  final List<BleConnectionPriority> priorityRequests = <BleConnectionPriority>[];
+  final List<BleConnectionPriority> priorityRequests =
+      <BleConnectionPriority>[];
   final Set<String> rejectedPairIds = <String>{};
   final Map<String, List<BleService>> servicesByDevice =
       <String, List<BleService>>{};
@@ -168,8 +169,7 @@ class _FakeUniversalBlePlatform extends UniversalBlePlatform {
   ) async {
     gattCalls.add('subscribe');
     subscribeCalls.add(deviceId);
-    final remainingGattFailures =
-        transientGattSubscribeFailures[deviceId] ?? 0;
+    final remainingGattFailures = transientGattSubscribeFailures[deviceId] ?? 0;
     if (remainingGattFailures > 0) {
       transientGattSubscribeFailures[deviceId] = remainingGattFailures - 1;
       updateConnection(deviceId, false);
@@ -473,10 +473,7 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 5));
 
     expect(fakePlatform.connectCalls, <String>['ble-sub-133', 'ble-sub-133']);
-    expect(fakePlatform.subscribeCalls, <String>[
-      'ble-sub-133',
-      'ble-sub-133',
-    ]);
+    expect(fakePlatform.subscribeCalls, <String>['ble-sub-133', 'ble-sub-133']);
     expect(device.connected, isTrue);
     expect((await transport.devices).single.id, 'ble-sub-133');
   });
@@ -503,7 +500,10 @@ void main() {
     await transport.connectToDevice(device);
     await Future<void>.delayed(const Duration(milliseconds: 5));
 
-    expect(fakePlatform.connectCalls, <String>['ble-disc-drop', 'ble-disc-drop']);
+    expect(fakePlatform.connectCalls, <String>[
+      'ble-disc-drop',
+      'ble-disc-drop',
+    ]);
     expect(device.connected, isTrue);
     expect((await transport.devices).single.id, 'ble-disc-drop');
   });
@@ -868,7 +868,13 @@ void main() {
   // long a firmware transfer takes.
   Uint8List firmwareSysEx([int marker = 0x00]) {
     return Uint8List.fromList(<int>[
-      0xF0, 0x7E, 0x10, 0x07, 0x02, 0x00, 0x7F,
+      0xF0,
+      0x7E,
+      0x10,
+      0x07,
+      0x02,
+      0x00,
+      0x7F,
       ...List<int>.filled(128, marker),
       0x2A,
       0xF7,
@@ -976,17 +982,20 @@ void main() {
     ]);
   });
 
-  test('requestHighPerformanceConnection: false requests no priority', () async {
-    final relaxed = UniversalBleMidiTransport(
-      requestHighPerformanceConnection: false,
-    );
-    final device = await connectDevice(relaxed, 'ble-priority-opt-out');
-    relaxed.disconnectDevice(device);
-    await Future<void>.delayed(const Duration(milliseconds: 5));
+  test(
+    'requestHighPerformanceConnection: false requests no priority',
+    () async {
+      final relaxed = UniversalBleMidiTransport(
+        requestHighPerformanceConnection: false,
+      );
+      final device = await connectDevice(relaxed, 'ble-priority-opt-out');
+      relaxed.disconnectDevice(device);
+      await Future<void>.delayed(const Duration(milliseconds: 5));
 
-    expect(fakePlatform.priorityRequests, isEmpty);
-    relaxed.teardown();
-  });
+      expect(fakePlatform.priorityRequests, isEmpty);
+      relaxed.teardown();
+    },
+  );
 
   test('overlapping sends do not interleave their SysEx packets', () async {
     fakePlatform.negotiatedMtu = 23; // Force multi-packet SysEx.
@@ -1009,29 +1018,40 @@ void main() {
         .toList();
     final firstTwo = markers.indexOf(2);
     expect(firstTwo, greaterThan(0), reason: 'no packets for message 1');
-    expect(markers.sublist(0, firstTwo).every((m) => m == 1), isTrue,
-        reason: 'interleaved packet ordering: $markers');
-    expect(markers.sublist(firstTwo).every((m) => m == 2), isTrue,
-        reason: 'interleaved packet ordering: $markers');
-  });
-
-  test('sendDataAwaitingDelivery completes only after the writes land',
-      () async {
-    fakePlatform.negotiatedMtu = 23;
-    fakePlatform.writeDelay = const Duration(milliseconds: 2);
-    await connectDevice(transport, 'ble-awaited');
-    fakePlatform.writtenPackets.clear();
-
-    final delivered = transport.sendDataAwaitingDelivery(
-      firmwareSysEx(0x01),
-      deviceId: 'ble-awaited',
+    expect(
+      markers.sublist(0, firstTwo).every((m) => m == 1),
+      isTrue,
+      reason: 'interleaved packet ordering: $markers',
     );
-    expect(fakePlatform.writtenPackets.length, lessThan(8),
-        reason: 'writes should still be in flight immediately after the call');
-
-    await delivered;
-    expect(fakePlatform.writtenPackets, hasLength(8));
+    expect(
+      markers.sublist(firstTwo).every((m) => m == 2),
+      isTrue,
+      reason: 'interleaved packet ordering: $markers',
+    );
   });
+
+  test(
+    'sendDataAwaitingDelivery completes only after the writes land',
+    () async {
+      fakePlatform.negotiatedMtu = 23;
+      fakePlatform.writeDelay = const Duration(milliseconds: 2);
+      await connectDevice(transport, 'ble-awaited');
+      fakePlatform.writtenPackets.clear();
+
+      final delivered = transport.sendDataAwaitingDelivery(
+        firmwareSysEx(0x01),
+        deviceId: 'ble-awaited',
+      );
+      expect(
+        fakePlatform.writtenPackets.length,
+        lessThan(8),
+        reason: 'writes should still be in flight immediately after the call',
+      );
+
+      await delivered;
+      expect(fakePlatform.writtenPackets, hasLength(8));
+    },
+  );
 
   test('a failed write is reported and the SysEx still completes', () async {
     fakePlatform.negotiatedMtu = 23;

--- a/packages/flutter_midi_command_platform_interface/lib/midi_ble_transport.dart
+++ b/packages/flutter_midi_command_platform_interface/lib/midi_ble_transport.dart
@@ -47,8 +47,7 @@ abstract class MidiBleTransport {
     Uint8List data, {
     int? timestamp,
     String? deviceId,
-  }) async =>
-      sendData(data, timestamp: timestamp, deviceId: deviceId);
+  }) async => sendData(data, timestamp: timestamp, deviceId: deviceId);
   Stream<MidiPacket> get onMidiDataReceived;
   Stream<MidiSetupChange> get onMidiSetupChanged;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -92,15 +92,15 @@ melos:
     analyze:example:
       run: dart run melos exec --scope=flutter_midi_command_example -- "flutter analyze"
     test:
-      run: dart run melos exec --dir-exists=test --concurrency=1 --ignore=flutter_midi_command_example --ignore=flutter_midi_command_web -- "flutter test"
+      # The example is included: its widget tests cover the app-facing wiring
+      # (transport toggles, connection error mapping) that no package test does.
+      run: dart run melos exec --dir-exists=test --concurrency=1 --ignore=flutter_midi_command_web -- "flutter test"
     test:web:chrome:
       run: dart run melos exec --scope=flutter_midi_command_web -- "flutter test --platform chrome"
     test:native:android:
       run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest
     test:native:darwin:
       run: bash tool/darwin_native_checks.sh
-    test:native:linux:
-      run: dart run melos exec --scope=flutter_midi_command_linux -- "flutter test"
     test:native:windows:
       run: dart run melos exec --scope=flutter_midi_command_windows -- "flutter test"
     test:example:integration:android:
@@ -129,3 +129,10 @@ melos:
       run: dart run melos exec --scope=flutter_midi_command_example -- "flutter build web --debug"
     format:
       run: dart run melos exec -- "dart format --set-exit-if-changed ."
+    format:check:
+      # Same check without rewriting, for CI.
+      run: dart run melos exec -- "dart format --output=none --set-exit-if-changed ."
+    publish:dry-run:
+      # Catches packaging regressions (missing LICENSE/README, unresolvable
+      # constraints) on the PR that introduces them rather than at release.
+      run: dart run melos exec --no-private --concurrency=1 -- "flutter pub publish --dry-run"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,7 +98,9 @@ melos:
     test:web:chrome:
       run: dart run melos exec --scope=flutter_midi_command_web -- "flutter test --platform chrome"
     test:native:android:
-      run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest
+      # `assembleDebug` on the BLE package compiles its Android plugin, which
+      # otherwise only builds as a side effect of the example app job.
+      run: bash ./example/android/gradlew -p example/android :flutter_midi_command_android:testDebugUnitTest :flutter_midi_command_ble:assembleDebug
     test:native:darwin:
       run: bash tool/darwin_native_checks.sh
     test:native:windows:


### PR DESCRIPTION
Follow-up to the CI audit that produced #176. Each item below was verified against what the jobs actually execute, not what their names imply.

## Gaps closed

**Formatting was never checked — and master was already unformatted.**
A `format` script existed in `pubspec.yaml` but no job ran it. `dart format --output=none --set-exit-if-changed` reported four drifted files (`flutter_midi_command_ble.dart`, its two test files, `midi_ble_transport.dart`); they're reformatted here. Adds a non-rewriting `format:check` script and runs it in `dart_checks`.

**`example/test/widget_test.dart` ran nowhere.**
`melos run test` passed `--ignore=flutter_midi_command_example`, and the only example test any job ran was `smoke_web_test.dart` in the web job. So a widget test plus a `connectionErrorMessage` unit test — over 230 lines of fakes in `example/test/support/` — were dead weight. The ignore is dropped; the example's 3 tests now run in `dart_checks`.

**Nothing verified the packages are still publishable.**
Adds `publish:dry-run` (`flutter pub publish --dry-run` across non-private packages) to `dart_checks`, so a missing LICENSE, a stale internal constraint or a packaging problem fails on the PR that introduces it rather than at release. All eight packages pass today.

**The BLE package's Android plugin compiled only in the example app job.**
`test:native:android` ran just the android package's Kotlin unit tests, so `FlutterMidiCommandBlePlugin.java` was first compiled by `example_android`, much later and reported as an app-build failure. `:flutter_midi_command_ble:assembleDebug` joins the native task (~2s warm).

**`native_linux_checks` added no signal.**
It ran `melos exec --scope=flutter_midi_command_linux -- flutter test` on `ubuntu-latest` — the same command on the same OS `dart_checks` had already run minutes earlier, while reading as native coverage. The linux backend is pure Dart, so the job is removed and `example_linux` (which does exercise it on a Linux host) now depends on `dart_checks` directly. The redundant `test:native:linux` script is removed with it.

**No concurrency control.** Rapid pushes ran all jobs concurrently, macOS and emulator included. Adds a concurrency group that cancels superseded runs on PRs (never on `master` pushes).

**Stale trigger.** Drops the `codex/restructure-repo-into-mono-repo-with-melon` push branch.

## Verification

Every new or changed script was run locally, and the two that gate on failure were checked against a deliberate break rather than only a passing run:

- `format:check` passes after the reformat;
- `melos run test` reports `flutter_midi_command_example: SUCCESS` alongside the other packages;
- `publish:dry-run` exits 0 across all eight packages on a clean tree;
- the android task exits non-zero on an injected Java syntax error.

One thing the dry-run surfaced while my tree was dirty: it reports the root package as **274 MB** if the darwin Swift build output from #176's script is present but not gitignored. #176 adds those `.gitignore` entries, which turns out to matter more than tidiness — pub.dev's limit is 100 MB. Clean, the root package is 403 KB.

## Left alone deliberately

- **The declared Flutter floor looks inconsistent.** The pubspecs pair `sdk: ">=3.11.4"` with `flutter: ">=3.24.0"`, and those are far apart — Dart 3.11 ships with a much newer Flutter than 3.24. Resolution is gated by the Dart constraint, so nothing is broken for users, but the `flutter` line is misleading and CI only ever tests the pinned 3.44.2. Correcting a published floor is a maintainer call, so I've only flagged it.
- **Example builds remain debug-only**, so release-mode failures (tree-shaking, stripped assertions) still go unseen.
- **The Windows C++ plugin** still compiles only via `example_windows`. Unlike the BLE case there's no cheap standalone task for it short of a full `flutter build windows`, which that job already does.

## Note on merge order

The reformat touches `packages/flutter_midi_command_ble/lib/flutter_midi_command_ble.dart` and its test file, which #168 also modifies. Whichever merges second needs a rebase; #168 is the smaller of the two.