### PR TITLE
chore: release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+ - FIX: `addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` return `Future<void>` instead of `void`. The platform call was previously discarded, so a failure such as `PlatformException(AUDIOERROR, Error -2 while create MIDI virtual source)` escaped as an unhandled asynchronous error that no `try`/`catch` around the call could see. Await them to handle failures. Existing calls that ignore the result keep compiling; custom `MidiCommandPlatform` implementations must widen these three overrides from `void`.
+ - FIX(ios): the system "Allow [app] to find devices on local networks" prompt no longer appears at app startup. The MIDI network session is created on the first `setNetworkSessionEnabled(true)` rather than at plugin init, so apps using only Bluetooth, USB or virtual MIDI never trigger it. Thanks to @aleksei-svezhevskii for the fix.
+ - Update federated package constraints to `^1.2.0`.
+
 ## 1.1.2
 
  - FIX(ble): retry a connection sequence whose link was torn down mid-handshake. universal_ble reports that as `deviceDisconnected` rather than a GATT status, so the retry shipped in 1.1.1 did not apply. Unlike a GATT status the code cannot arise from a peripheral that was never reachable, so it is honoured on every platform.

--- a/packages/flutter_midi_command_android/CHANGELOG.md
+++ b/packages/flutter_midi_command_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+ - Bump "flutter_midi_command_android" to `1.2.0` and update the platform interface dependency constraint to `^1.2.0`.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_android" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_android/pubspec.yaml
+++ b/packages/flutter_midi_command_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_android
 description: The Android implementation of flutter_midi_command, bridging the platform MIDI APIs to send and receive MIDI messages.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_android
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_midi_command_ble/CHANGELOG.md
+++ b/packages/flutter_midi_command_ble/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+ - Bump "flutter_midi_command_ble" to `1.2.0` and update the platform interface dependency constraint to `^1.2.0`.
+
 ## 1.1.2
 
  - FIX: treat `deviceDisconnected` during the connection sequence as a transient link failure and retry it. universal_ble fails every in-flight GATT operation with this code when an established connection is torn down, so a link that dropped with service discovery or subscription pending reported it rather than a GATT status and was never retried — 1.1.1 covered the same failure only where Android named it as a GATT status. Unlike a GATT status it cannot arise from a peripheral that was never reachable — there has to have been a connection to lose — so it is the least ambiguous of the three signals, and it applies on every platform rather than only Android.

--- a/packages/flutter_midi_command_ble/pubspec.yaml
+++ b/packages/flutter_midi_command_ble/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_ble
 description: Shared BLE MIDI transport for flutter_midi_command based on universal_ble.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_ble
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
   universal_ble: ^2.1.1
 
 dev_dependencies:

--- a/packages/flutter_midi_command_darwin/.pubignore
+++ b/packages/flutter_midi_command_darwin/.pubignore
@@ -18,8 +18,12 @@ build/
 **/build/
 pubspec.lock
 
-# Darwin build products.
-ios/.build/
+# Darwin build products. `tool/darwin_native_checks.sh` writes these; the path
+# moved with the federation, and the stale `ios/.build/` rule left the published
+# archive at ~270 MB instead of ~18 KB. A parent .gitignore does not apply to a
+# package in a subdirectory, so they have to be listed here.
+darwin/flutter_midi_command_darwin/.build/
+darwin/flutter_midi_command_darwin/.build-ios/
 
 # OS-specific metadata.
 .DS_Store

--- a/packages/flutter_midi_command_darwin/CHANGELOG.md
+++ b/packages/flutter_midi_command_darwin/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+ - FIX(ios): do not create `MIDINetworkSession.default()` at plugin init. Touching it made iOS 14+ show the system "Allow [app] to find devices on local networks" permission prompt at app startup, even though network MIDI is disabled by default. The session is now created lazily in `setNetworkSessionEnabled(true)`, the existing explicit opt-in for network (RTP) MIDI. Thanks to @aleksei-svezhevskii.
+ - Bump "flutter_midi_command_darwin" to `1.2.0` and update the platform interface dependency constraint to `^1.2.0`.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_darwin" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_darwin/pubspec.yaml
+++ b/packages/flutter_midi_command_darwin/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_darwin
 description: Darwin (iOS/macOS) serial MIDI wrapper for flutter_midi_command.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_darwin
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_midi_command_linux/CHANGELOG.md
+++ b/packages/flutter_midi_command_linux/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+ - FIX: widen `addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` to `Future<void>`, matching the platform interface.
+ - Bump "flutter_midi_command_linux" to `1.2.0` and update the platform interface dependency constraint to `^1.2.0`.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_linux" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_linux/pubspec.yaml
+++ b/packages/flutter_midi_command_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_linux
 description: The Linux implementation of flutter_midi_command, using ALSA sequencer to send and receive MIDI messages.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_linux
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
   ffi: ^2.0.1
 
 dev_dependencies:

--- a/packages/flutter_midi_command_platform_interface/CHANGELOG.md
+++ b/packages/flutter_midi_command_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+ - FIX: `addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` return `Future<void>` instead of `void` on both `MidiCommandPlatform` and `MethodChannelMidiCommand`, which no longer discards the host API call. Platform implementations must widen these three overrides from `void`.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_platform_interface" to `1.1.2` for the synchronized workspace release.

--- a/packages/flutter_midi_command_platform_interface/pubspec.yaml
+++ b/packages/flutter_midi_command_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_platform_interface
 description: A common platform interface for the FlutterMidiCommand plugin.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_platform_interface
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues

--- a/packages/flutter_midi_command_web/CHANGELOG.md
+++ b/packages/flutter_midi_command_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+ - FIX: widen `addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` to `Future<void>`, matching the platform interface. The unsupported-operation errors for virtual devices now arrive through the returned future.
+ - Bump "flutter_midi_command_web" to `1.2.0` and update the platform interface dependency constraint to `^1.2.0`.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_web" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_web/pubspec.yaml
+++ b/packages/flutter_midi_command_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_web
 description: The web implementation of flutter_midi_command, using the browser Web MIDI API to send and receive MIDI messages.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_web
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -25,7 +25,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   web: ^1.1.1
-  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_midi_command_windows/CHANGELOG.md
+++ b/packages/flutter_midi_command_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.0
+
+ - FIX: widen `addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` to `Future<void>`, matching the platform interface.
+ - Bump "flutter_midi_command_windows" to `1.2.0` and update the platform interface dependency constraint to `^1.2.0`.
+
 ## 1.1.2
 
  - Bump "flutter_midi_command_windows" to `1.1.2` and update the platform interface dependency constraint to `^1.1.2`.

--- a/packages/flutter_midi_command_windows/pubspec.yaml
+++ b/packages/flutter_midi_command_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_midi_command_windows
 description: The Windows implementation of flutter_midi_command, using the WinMM MIDI API to send and receive MIDI messages.
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand/tree/main/packages/flutter_midi_command_windows
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -22,7 +22,7 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  flutter_midi_command_platform_interface: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
   ffi: ^2.1.4
   win32: ^6.3.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_midi_command
 description: A Flutter plugin for sending and receiving MIDI messages between Flutter and physical and virtual MIDI devices.
 
-version: 1.1.2
+version: 1.2.0
 homepage: https://github.com/InvisibleWrench/FlutterMidiCommand
 repository: https://github.com/InvisibleWrench/FlutterMidiCommand
 issue_tracker: https://github.com/InvisibleWrench/FlutterMidiCommand/issues
@@ -35,12 +35,12 @@ dependencies:
   flutter:
     sdk: flutter
   async: ^2.12.0
-  flutter_midi_command_platform_interface: ^1.1.2
-  flutter_midi_command_linux: ^1.1.2
-  flutter_midi_command_windows: ^1.1.2
-  flutter_midi_command_web: ^1.1.2
-  flutter_midi_command_android: ^1.1.2
-  flutter_midi_command_darwin: ^1.1.2
+  flutter_midi_command_platform_interface: ^1.2.0
+  flutter_midi_command_linux: ^1.2.0
+  flutter_midi_command_windows: ^1.2.0
+  flutter_midi_command_web: ^1.2.0
+  flutter_midi_command_android: ^1.2.0
+  flutter_midi_command_darwin: ^1.2.0
     
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Versions all eight packages at **1.2.0** with changelogs. Prepared on top of master at c90f5de; #168 is deliberately **not** included and will land in the next release.

## What's in it

- **`addVirtualDevice`, `removeVirtualDevice` and `setNetworkSessionEnabled` return `Future<void>`** (#173 → #174). The platform call was previously discarded, so failures escaped as unhandled asynchronous errors that no `try`/`catch` at the call site could see.
- **iOS no longer shows the local-network permission prompt at app startup** (#175, thanks @aleksei-svezhevskii). The MIDI network session is created on the first `setNetworkSessionEnabled(true)` instead of at plugin init.
- CI-only work from #176 and #177 (darwin compile + Swift tests, format/publish/example checks) — no user-facing change, so it appears only as the version bump in the packages it touched.

## Why minor, not patch

The three signature changes are source-compatible for callers that ignore the result, but anyone implementing `MidiCommandPlatform` must widen those overrides from `void`. That is more than a patch communicates, so 1.1.2 → 1.2.0.

## Also fixed here: a publish blocker

While verifying, `publish:dry-run` measured the darwin package at **273 MB** instead of 18 KB. Its `.pubignore` still excluded the pre-federation `ios/.build/` path, so the Swift build output that `tool/darwin_native_checks.sh` now produces was being packaged. pub.dev's limit is 100 MB, so a publish from any machine that had run the darwin checks would have failed — including the local publish flow this repo uses. The `.gitignore` entries added in #176 do not help, because a parent `.gitignore` does not apply to a package in a subdirectory; the paths have to be in `.pubignore`. Verified: with 252 MB of `.build` present, the archive is back to 19 KB.

## Verification

On the committed release branch: `melos bootstrap` (9 packages), `format:check`, `analyze`, `analyze:example`, `test` (6 packages), `test:web:chrome`, `tool/darwin_native_checks.sh` (5 Swift tests) and `publish:dry-run` all pass — the last reporting **0 warnings for all eight packages**.

## Before publishing

- There is **no `v1.1.2` tag** — the tag series stops at `v1.1.1`, so 1.1.2 shipped untagged. Worth creating it retroactively at e1e988c alongside `v1.2.0`, otherwise any future `melos version` run computes its commit range from `v1.1.1`.
- Publish order still matters, since the `^1.2.0` constraints are not on pub.dev yet: `flutter_midi_command_platform_interface` first, then the six implementation packages, then `flutter_midi_command`.